### PR TITLE
Marvell: Update Dockerfiles for staged builds

### DIFF
--- a/platform/innovium/docker-saiserver-invm/Dockerfile.j2
+++ b/platform/innovium/docker-saiserver-invm/Dockerfile.j2
@@ -1,5 +1,7 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ARG docker_container_name
 
@@ -38,4 +40,9 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
+FROM $BASE
+
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
@@ -1,14 +1,10 @@
-FROM docker-syncd-invm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-{% from "dockers/dockerfile-macros.j2" import install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+ARG BASE=docker-syncd-invm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
-
-COPY \
-{% for deb in docker_syncd_invm_rpc_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
 
 RUN apt-get purge -y syncd
 
@@ -33,10 +29,6 @@ RUN apt-get update \
     libnanomsg5           \
     libnanomsg-dev
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_invm_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
 
 RUN pip3 install cffi \
  && pip3 install nnpy   \
@@ -46,19 +38,21 @@ RUN pip3 install cffi \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-{% if docker_syncd_invm_rpc_whls.strip() -%}
-# Copy locally-built Python wheel dependencies
-{{ copy_files("python-wheels/", docker_syncd_invm_rpc_whls.split(' '), "/python-wheels/") }}
-
-# Install locally-built Python wheel dependencies
-{{ install_python_wheels(docker_syncd_invm_rpc_whls.split(' ')) }}
-{% endif %}
-
+{% if docker_syncd_invm_rpc_debs.strip() -%}
+# Copy built Debian packages
+{{ copy_files("debs/", docker_syncd_invm_rpc_debs.split(' '), "/debs/") }}
+# Install built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_invm_rpc_debs.split(' ')) }}
+{%- endif %}
 
 ## Clean up
 RUN apt-get purge -y libyaml-dev python3-dev libffi-dev libssl-dev wget cmake \
     build-essential
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /root/deps
 
+FROM $BASE
+
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/innovium/docker-syncd-invm/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm/Dockerfile.j2
@@ -1,5 +1,7 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ARG docker_container_name
 
@@ -7,12 +9,6 @@ ARG docker_container_name
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-
-COPY \
-{% for deb in docker_syncd_invm_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
 
 # Needed for Innovium Debug Shell
 RUN apt-get install -y net-tools
@@ -22,10 +18,13 @@ RUN apt-get install -y binutils
 RUN pip3 install numpy
 RUN pip3 install yamlordereddictloader
 
-RUN dpkg -i \
-{% for deb in docker_syncd_invm_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+{% if docker_syncd_invm_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_syncd_invm_debs.split(' '), "/debs/") }}
+
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_invm_debs.split(' ')) }}
+{%- endif %}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["ivm_start.sh", "/usr/bin/"]
@@ -33,8 +32,9 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+FROM $BASE
 
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell/docker-saiserver-mrvl/Dockerfile.j2
+++ b/platform/marvell/docker-saiserver-mrvl/Dockerfile.j2
@@ -1,5 +1,7 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ARG docker_container_name
 
@@ -32,4 +34,9 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
+FROM $BASE
+
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -1,14 +1,10 @@
-FROM docker-syncd-mrvl-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-{% from "dockers/dockerfile-macros.j2" import install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+ARG BASE=docker-syncd-mrvl-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
-
-COPY \
-{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
 
 RUN apt-get purge -y syncd
 
@@ -30,10 +26,12 @@ RUN apt-get update \
     libnanomsg5           \
     libnanomsg-dev
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
+{% if docker_syncd_mrvl_rpc_debs.strip() -%}
+# Copy built Debian packages
+{{ copy_files("debs/", docker_syncd_mrvl_rpc_debs.split(' '), "/debs/") }}
+# Install built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mrvl_rpc_debs.split(' ')) }}
+{%- endif %}
 
 RUN pip3 install cffi    \
  && pip3 install nnpy    \
@@ -53,7 +51,11 @@ COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
 ## Clean up
 RUN apt-get purge -y libyaml-dev python3-dev libffi-dev libssl-dev wget build-essential
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /root/deps
 
+FROM $BASE
+
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
@@ -1,5 +1,7 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, copy_files %}
+ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+FROM $BASE as base
 
 ARG docker_container_name
 
@@ -8,12 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-COPY \
-{% for deb in docker_syncd_mrvl_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-
 RUN apt-get update \
  && apt-get -y install  \
     net-tools           \
@@ -21,17 +17,20 @@ RUN apt-get update \
 
 RUN apt-get -y install libpcap-dev libxml2-dev python3-dev swig
 
-RUN dpkg -i \
-{% for deb in docker_syncd_mrvl_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+{% if docker_syncd_mrvl_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_syncd_mrvl_debs.split(' '), "/debs/") }}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mrvl_debs.split(' ')) }}
+{%- endif %}
 
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin/"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+FROM $BASE
 
+COPY --from=base / /
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION
#### Why I did it
This PR is for syncd side of changes for marvell platforms for the sonic-buildimage PR #19952

#### How I did it
Added Dockerfile changes similar to the base docker changes

#### How to verify it
Build marvell platform builds and load in marvell platforms and verify link up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog


#### A picture of a cute animal (not mandatory but encouraged)

