### PR TITLE
Fix tacacs build issue on trixie

### DIFF
--- a/src/tacacs/audisp/patches/0003-Add-local-accounting.patch
+++ b/src/tacacs/audisp/patches/0003-Add-local-accounting.patch
@@ -21,8 +21,9 @@ index b6cb92b..dacc8fd 100644
  	audisp-tac_plus.conf audisp-tacplus.conf
  
 -audisp_tacplus_SOURCES = audisp-tacplus.c password.c regex_helper.c trace.c sudoers_helper.c
+-audisp_tacplus_CFLAGS = -O
 +audisp_tacplus_SOURCES = audisp-tacplus.c password.c regex_helper.c trace.c local_accounting.c sudoers_helper.c
- audisp_tacplus_CFLAGS = -O
++audisp_tacplus_CFLAGS = -O  -Wno-stringop-truncation
  audisp_tacplus_LDADD = -lauparse -ltacsupport -ltac
  sbin_PROGRAMS = audisp-tacplus
 diff --git a/audisp-tacplus.c b/audisp-tacplus.c

--- a/src/tacacs/bash_tacplus/unittest/Makefile.am
+++ b/src/tacacs/bash_tacplus/unittest/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = plugin_test
 TESTS = plugin_test
 
 # Use a custom CFLAGS override because Trixie will add -Werror=implicit-function-declaration to the default CFLAGS.
-CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection
+CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security
 
 # disable some warning because UT need test functions not in header file.
 CFLAGS_TEST = -Wno-parentheses -Wno-format-security -Wno-implicit-function-declaration -Wno-int-to-pointer-cast

--- a/src/tacacs/bash_tacplus/unittest/Makefile.am
+++ b/src/tacacs/bash_tacplus/unittest/Makefile.am
@@ -3,6 +3,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 noinst_PROGRAMS = plugin_test
 TESTS = plugin_test
 
+CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection
+
 # disable some warning because UT need test functions not in header file.
 CFLAGS_TEST = -Wno-parentheses -Wno-format-security -Wno-implicit-function-declaration -Wno-int-to-pointer-cast
 IFLAGS_TEST = -I.. -I../include -I../lib
@@ -10,5 +12,5 @@ DBGFLAGS = -DDEBUG -DBASH_PLUGIN_UT
 
 plugin_test_SOURCES = plugin_test.c mock_helper.c ../bash_tacplus.c
 
-plugin_test_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
+plugin_test_CFLAGS = $(DBGFLAGS) $(CFLAGS_TEST) $(IFLAGS_TEST)
 plugin_test_LDADD = -lc -lcunit

--- a/src/tacacs/bash_tacplus/unittest/Makefile.am
+++ b/src/tacacs/bash_tacplus/unittest/Makefile.am
@@ -3,6 +3,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 noinst_PROGRAMS = plugin_test
 TESTS = plugin_test
 
+# Use a custom CFLAGS override because Trixie will add -Werror=implicit-function-declaration to the default CFLAGS.
 CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection
 
 # disable some warning because UT need test functions not in header file.
@@ -12,5 +13,5 @@ DBGFLAGS = -DDEBUG -DBASH_PLUGIN_UT
 
 plugin_test_SOURCES = plugin_test.c mock_helper.c ../bash_tacplus.c
 
-plugin_test_CFLAGS = $(DBGFLAGS) $(CFLAGS_TEST) $(IFLAGS_TEST)
+plugin_test_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
 plugin_test_LDADD = -lc -lcunit


### PR DESCRIPTION
Fix tacacs build issue on trixie

#### Why I did it
Fix https://github.com/sonic-net/sonic-buildimage/issues/23795
Trixie using different build c flag, which cause tacacs project build failed.

#### How I did it
Remove -Werror=implicit-function-declaration from testcase CFLAGS
Add -Wno-stringop-truncation to CFLAGS

#### How to verify it
Manually verify build success
Verify build with https://github.com/sonic-net/sonic-buildimage/pull/23988

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
Fix tacacs build issue on trixie

#### A picture of a cute animal (not mandatory but encouraged)

