### PR TITLE
Resolve boot errors on s5248

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -303,7 +303,8 @@ sudo LANG=C chroot $FILESYSTEM_ROOT usermod -aG redis $USERNAME
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     ## Pre-install hardware drivers
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install      \
-        firmware-linux-nonfree
+        firmware-linux-nonfree \
+        firmware-intel-misc
 fi
 
 ## Pre-install the fundamental packages

--- a/device/dell/x86_64-dell_e3224f-r0/installer.conf
+++ b/device/dell/x86_64-dell_e3224f-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 VAR_LOG_SIZE=512
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="intel_iommu=off irqfixup"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="intel_iommu=off irqfixup modprobe.blacklist=pinctrl_denverton"

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/installer.conf
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="intel_iommu=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="intel_iommu=off modprobe.blacklist=pinctrl_denverton"


### PR DESCRIPTION
code changes to resolve the following boot errors
[    5.593106] c3xxx 0000:01:00.0: Failed to load MMP firmware qat_c3xxx_mmp.bin
[    5.600277] c3xxx 0000:01:00.0: Failed to load acceleration FW
[    5.719590] c3xxx 0000:01:00.0: probe with driver c3xxx failed with error -14

denverton-pinctrl denverton-pinctrl.0: probe with driver denverton-pinctrl failed with error -61