### PR TITLE
[Debian 13] [nvidia-bluefield] Fix the slow nvidia-bluefield build in SDK makefile

### DIFF
--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -62,11 +62,11 @@ SDK_ONLINE_TARGETS =
 
 # OFED and derived packages
 
-OFED_VER_SHORT = $(call get_sdk_package_version_short,"ofed")
-OFED_VER_FULL = $(call get_sdk_package_version_full,"ofed")
-OFED_KERNEL_VER_SHORT = $(call get_sdk_package_version_short,"mlnx-ofed-kernel")
-OFED_KERNEL_VER_FULL = $(call get_sdk_package_version_full,"mlnx-ofed-kernel")
-MLNX_TOOLS_VER = $(call get_sdk_package_version_full,"mlnx-tools")
+OFED_VER_SHORT := $(call get_sdk_package_version_short,"ofed")
+OFED_VER_FULL := $(call get_sdk_package_version_full,"ofed")
+OFED_KERNEL_VER_SHORT := $(call get_sdk_package_version_short,"mlnx-ofed-kernel")
+OFED_KERNEL_VER_FULL := $(call get_sdk_package_version_full,"mlnx-ofed-kernel")
+MLNX_TOOLS_VER := $(call get_sdk_package_version_full,"mlnx-tools")
 
 MLNX_TOOLS = mlnx-tools_$(MLNX_TOOLS_VER)_arm64.deb
 $(MLNX_TOOLS)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/ofed
@@ -93,7 +93,7 @@ SDK_DEBS += $(MLNX_TOOLS) $(OFED_KERNEL_UTILS)
 SDK_SRC_TARGETS += $(MLNX_TOOLS)
 
 # MLNX iproute2
-MLNX_IPROUTE2_VER = $(call get_sdk_package_version_full,"mlnx-iproute2")
+MLNX_IPROUTE2_VER := $(call get_sdk_package_version_full,"mlnx-iproute2")
 
 MLNX_IPROUTE2 = mlnx-iproute2_$(MLNX_IPROUTE2_VER)_arm64.deb
 $(MLNX_IPROUTE2)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/mlnx-iproute2
@@ -109,7 +109,7 @@ SDK_SRC_TARGETS += $(MLNX_IPROUTE2)
 
 # RDMA and derived packages
 
-RDMA_CORE_VER = $(call get_sdk_package_version_full,"rdma-core")
+RDMA_CORE_VER := $(call get_sdk_package_version_full,"rdma-core")
 RDMA_CORE = rdma-core_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 $(RDMA_CORE)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/rdma
 $(RDMA_CORE)_RDEPENDS = $(LIBNL3)
@@ -164,7 +164,7 @@ endif
 
 # DPDK and derived packages
 
-DPDK_VER = $(call get_sdk_package_version_full,"dpdk")
+DPDK_VER := $(call get_sdk_package_version_full,"dpdk")
 
 DPDK = mlnx-dpdk_${DPDK_VER}_${CONFIGURED_ARCH}.deb
 $(DPDK)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/dpdk
@@ -186,7 +186,7 @@ SDK_SRC_TARGETS += $(DPDK)
 
 # RXP compiler and derived packages
 
-RXPCOMPILER_VER = $(call get_sdk_package_version_full,"rxp-tools")
+RXPCOMPILER_VER := $(call get_sdk_package_version_full,"rxp-tools")
 
 RXPCOMPILER = rxp-compiler_$(RXPCOMPILER_VER)_arm64.deb
 $(RXPCOMPILER)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/rxp-compiler
@@ -204,7 +204,7 @@ SDK_SRC_TARGETS += $(RXPCOMPILER)
 
 # GRPC and derived packages
 
-LIBGRPC_VER = $(call get_sdk_package_version_full,"grpc")
+LIBGRPC_VER := $(call get_sdk_package_version_full,"grpc")
 
 LIBGRPC_DEV = libgrpc-dev_$(LIBGRPC_VER)_arm64.deb
 $(LIBGRPC_DEV)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/grpc
@@ -216,8 +216,8 @@ SDK_SRC_TARGETS += $(LIBGRPC_DEV)
 
 # DOCA and derived packages
 
-DOCA_VERSION = $(call get_sdk_package_version_full,"doca")
-DOCA_DEB_VERSION = $(DOCA_VERSION)-1
+DOCA_VERSION := $(call get_sdk_package_version_full,"doca")
+DOCA_DEB_VERSION := $(DOCA_VERSION)-1
 
 DOCA_COMMON = doca-sdk-common_${DOCA_DEB_VERSION}_${CONFIGURED_ARCH}.deb
 $(DOCA_COMMON)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/doca
@@ -275,7 +275,7 @@ SONIC_ONLINE_DEBS += $(DOCA_DEBS) $(DOCA_DEV_DEBS)
 endif
 
 # hw-steering packages, needed for doca-flow runtime
-NV_HWS_VERSION = $(call get_sdk_package_version_full,"nv_hws")
+NV_HWS_VERSION := $(call get_sdk_package_version_full,"nv_hws")
 
 LIB_NV_HWS = libnvhws1_${NV_HWS_VERSION}_${CONFIGURED_ARCH}.deb
 $(LIB_NV_HWS)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/nv_hws
@@ -297,7 +297,7 @@ export LIB_NV_HWS LIB_NV_HWS_DEV
 
 # SDN Appliance
 
-SDN_APPL_VER=$(call get_sdk_package_version_full,"nasa")
+SDN_APPL_VER:=$(call get_sdk_package_version_full,"nasa")
 SDN_APPL = sdn-appliance_${SDN_APPL_VER}_${CONFIGURED_ARCH}.deb
 $(SDN_APPL)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sdn
 $(SDN_APPL)_RDEPENDS = $(DOCA_COMMON) $(DOCA_DEBS) $(MLNX_TOOLS) $(OFED_KERNEL_UTILS) $(MLNX_IPROUTE2)


### PR DESCRIPTION
Fix the slowness in nvidia-bluefield build because of recursive variable expansion in  SDK makefile 

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The following script was executed hundreds of time from sdk.mk 
/bin/bash platform/nvidia-bluefield/recipes/get_sdk_package_version.sh

#### How I did it
Convert recursive variable expansion to immediate expansion
#### How to verify it
Build sonic-nvidia-bluefield.bfb for Debian 13
