### PR TITLE
Fix python3.13 warnings for mellanox platform api

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -133,8 +133,8 @@ class ONIEUpdater(object):
     ONIE_FW_UPDATE_CMD_INSTALL = ['/usr/bin/mlnx-onie-fw-update.sh', 'update', '--no-reboot']
     ONIE_FW_UPDATE_CMD_SHOW_PENDING = ['/usr/bin/mlnx-onie-fw-update.sh', 'show-pending']
 
-    ONIE_VERSION_PARSE_PATTERN = '([0-9]{4})\.([0-9]{2})-([0-9]+)\.([0-9]+)\.([0-9]+)-?(rc[0-9]+)?-?(dev)?-([0-9]+)'
-    ONIE_VERSION_BASE_PARSE_PATTERN = '([0-9]+)\.([0-9]+)\.([0-9]+)'
+    ONIE_VERSION_PARSE_PATTERN = r'([0-9]{4})\.([0-9]{2})-([0-9]+)\.([0-9]+)\.([0-9]+)-?(rc[0-9]+)?-?(dev)?-([0-9]+)'
+    ONIE_VERSION_BASE_PARSE_PATTERN = r'([0-9]+)\.([0-9]+)\.([0-9]+)'
     ONIE_VERSION_REQUIRED = '5.2.0016'
 
     ONIE_VERSION_ATTR = 'onie_version'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
@@ -118,7 +118,7 @@ class Pcie(PcieUtil):
             #   2 hex digit of id
             #   dot '.'
             #   1 digit of fn
-            pattern_for_device_folder = re.search('....:(..):..\..', folder)
+            pattern_for_device_folder = re.search(r'....:(..):..\..', folder)
             if pattern_for_device_folder:
                 bus = pattern_for_device_folder.group(1)
                 with open(os.path.join('/sys/bus/pci/devices', folder, 'device'), 'r') as device_file:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Remove warnings from show command outputs that uses platform api
#### How I did it
Use raw strings compatible with python 3.13
#### How to verify it
Sonic must build for mellanox platform and musn't show warnings for show platform commands.
