### PR TITLE
Try to fix UEFI boot issue

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -581,17 +581,11 @@ cp $tmp_config /boot/efi/EFI/debian/grub.cfg
 # Add extra linux command line
 echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX $extra_cmdline_linux"
-GRUB_CFG_LINUX_CMD=""
-GRUB_CFG_INITRD_CMD=""
-if [ "$firmware" = "uefi" ] &&  expr "$secure_boot_state" : '[[:digit:]]\{1,\}' >/dev/null && [ "$secure_boot_state" -eq "$ENABLED" ]; then
-    # grub.cfg when BIOS is UEFI and support Secure Boot
-    GRUB_CFG_LINUX_CMD="linuxefi"
-    GRUB_CFG_INITRD_CMD="initrdefi"
-else
-    # grub.cfg when BIOS is Legacy
-    GRUB_CFG_LINUX_CMD="linux"
-    GRUB_CFG_INITRD_CMD="initrd"
-fi
+
+# Sonic grub 2.12-9 in Debian 13 drops use of 'linuxefi' and 'initrdefi' for UEFI systems.
+# The same command now works for both BIOS and UEFI systems.
+GRUB_CFG_LINUX_CMD="linux"
+GRUB_CFG_INITRD_CMD="initrd"
 
 cat <<EOF >> $grub_cfg
 menuentry '$demo_grub_entry' {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Debian 13 grub cannot boot Sonic trixie image without this change on uefi systems with secure boot enabled.
#### How I did it
Phase out use of 'linuxefi' and 'initrdefi' commands to load sonic trixie image.
#### How to verify it
sonic trixie image must boot on uefi systems with secure boot
