### PR TITLE
Update hsFlowd to close the pipe immediately

### DIFF
--- a/src/sflow/hsflowd/patch/0005-Use-close-range-syscall-over-blindly-looping-over-al.patch
+++ b/src/sflow/hsflowd/patch/0005-Use-close-range-syscall-over-blindly-looping-over-al.patch
@@ -1,0 +1,45 @@
+From 5adeafc4249af9bc6a8841cff8ebbc75fcf4b8e1 Mon Sep 17 00:00:00 2001
+From: vkarri <vkarri@contoso.com>
+Date: Tue, 21 Oct 2025 01:23:08 +0000
+Subject: [PATCH] From dfc83d5cf6cbfa9056c4892d5ad0c3d3ac667d4f Mon Sep 17
+ 00:00:00 2001 Subject: [PATCH]  Use close range syscall over blindly looping
+ over all FD
+
+getdtablesize is deprecated in Kernel 6.12 and Docker is returning a really large default number.
+So, hsflowd takes a lot of time to close all file descriptors and is blocking the service restart of hsflowd
+from sflowmgrd.
+---
+ src/Linux/hsflowd.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/Linux/hsflowd.c b/src/Linux/hsflowd.c
+index f7bd9a0..6170dc6 100644
+--- a/src/Linux/hsflowd.c
++++ b/src/Linux/hsflowd.c
+@@ -6,6 +6,8 @@
+ extern "C" {
+ #endif
+
++#define _GNU_SOURCE
++#include <unistd.h>
+ #include "hsflowd.h"
+ #include "cpu_utils.h"
+ #include "cJSON.h"
+@@ -1922,9 +1924,12 @@ extern "C" {
+ 	  exit(EXIT_FAILURE);
+ 	}
+ 
+-	// close all file descriptors
++	// close all file descriptors using close_range() (Kernel 5.9+)
+ 	int i;
+-	for(i=getdtablesize(); i >= 0; --i) close(i);
++	if(close_range(0, ~0U, 0) < 0) {
++	  myLog(LOG_ERR,"close_range failed: %s", strerror(errno));
++	  exit(EXIT_FAILURE);
++	}
+ 	// create stdin/out/err
+ 	// stdin
+ 	if((i = open("/dev/null",O_RDWR)) == -1) {
+-- 
+2.50.1
+

--- a/src/sflow/hsflowd/patch/series
+++ b/src/sflow/hsflowd/patch/series
@@ -2,3 +2,4 @@
 0002-host_sflow_debian.patch
 0003-sflow-enabled-drop-monitor-support-for-SONiC.patch
 0004-When-interface-removed-just-as-we-discover-it-log-wi.patch
+0005-Use-close-range-syscall-over-blindly-looping-over-al.patch


### PR DESCRIPTION

#### Why I did it

Without this fix, sflowmgrd is taking 10-20 mins to finish command service restart hsflowd in Debian 13

sflowmgrd trace
0  read () from /lib/x86_64-linux-gnu/libc.so.6
1  _IO_file_underflow () from /lib/x86_64-linux-gnu/libc.so.6 2  _IO_default_uflow () from /lib/x86_64-linux-gnu/libc.so.6 3  _IO_getline_info () from /lib/x86_64-linux-gnu/libc.so.6 4  fgets () from /lib/x86_64-linux-gnu/libc.so.6
5  swss::exec(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) () from /lib/x86_64-linux-gnu/libswsscommon.so.0 6  swss::SflowMgr::sflowHandleService (this=this@entry=0x7ffdc4ae6dc0,
    enable=enable@entry=true) at ./cfgmgr/sflowmgr.cpp:67
7  swss::SflowMgr::doTask (this=<optimized out>, consumer=...)
    at ./cfgmgr/sflowmgr.cpp:459
8  Consumer::execute (this=0x556f0715b280) at ../orchagent/orch.cpp:338 9  main (argc=<optimized out>, argv=<optimized out>)
    at ./cfgmgr/sflowmgrd.cpp:74

hsflowd trace:
(gdb) bt
close () from /lib/x86_64-linux-gnu/libc.so.6
main (argc=<optimized out>, argv=<optimized out>) at hsflowd.c:1927 (gdb) f 1
1927	hsflowd.c: No such file or directory.
(gdb) p i
$1 = 1035943704
(gdb) c
Continuing.
^C
Program received signal SIGINT, Interrupt.
0x00007fa33f48d9e0 in close () from /lib/x86_64-linux-gnu/libc.so.6 (gdb) f 1
1927	in hsflowd.c
(gdb) p i
$2 = 1024299507

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
     48 root      20   0    2652    928    820 R  92.4   0.0   5:24.66 hsflowd

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### How to verify it

sflow test musn't fail on Debian 13 trixie image