### PR TITLE
[nvidia-bluefield] Add immediate variable expansion to dpu makefiles

### DIFF
--- a/platform/nvidia-bluefield/mft/Makefile
+++ b/platform/nvidia-bluefield/mft/Makefile
@@ -27,7 +27,7 @@ else
 MFT_TGZ_URL = http://www.mellanox.com/downloads/MFT/$(MFT_TGZ)
 endif
 
-BUILD_ARCH = $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+BUILD_ARCH := $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 KERNEL_MFT_TARGET = kernel-mft-dkms-modules-$(KVERSION)_$(MFT_VERSION)_$(BUILD_ARCH).deb
 
 MAIN_TARGET = mft_$(MFT_VERSION)-$(MFT_REVISION)_arm64.deb

--- a/platform/nvidia-bluefield/recipes/mft.mk
+++ b/platform/nvidia-bluefield/recipes/mft.mk
@@ -36,7 +36,7 @@ $(eval $(call add_derived_package,$(MFT),$(MFT_OEM)))
 KERNEL_MFT_DKMS = kernel-mft-dkms_$(MFT_VERSION)-$(MFT_REVISION)_all.deb
 $(eval $(call add_derived_package,$(MFT),$(KERNEL_MFT_DKMS)))
 
-BUILD_ARCH = $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+BUILD_ARCH := $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 KERNEL_MFT = kernel-mft-dkms-modules-$(KVERSION)_$(MFT_VERSION)_$(BUILD_ARCH).deb
 $(KERNEL_MFT)_SRC_PATH = $(PLATFORM_PATH)/mft
 $(KERNEL_MFT)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON) $(KERNEL_MFT_DKMS)

--- a/platform/nvidia-bluefield/sdk-src/ofed/Makefile
+++ b/platform/nvidia-bluefield/sdk-src/ofed/Makefile
@@ -17,7 +17,7 @@
 
 .ONESHELL:
 SHELL = /bin/bash
-BUILD_ARCH = $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+BUILD_ARCH := $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 
 OFED_TAR = MLNX_OFED_SRC-debian-$(OFED_VER_FULL).tgz
 OFED_SRC = MLNX_OFED_SRC-$(OFED_VER_FULL)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BUILD_ARCH = $(shell dpkg-architecture -qDEB_BUILD_ARCH) is causing to be executed several times slowing dpu build

#### How I did it
Change it into immediate variable expansion

#### How to verify it
DPU build must succeed and will be a tad bit faster