### PR TITLE
Fix systemd sonic generator for SmartSwitch NPU

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -674,9 +674,9 @@ sudo cp $IMAGE_CONFIGS/midplane-network/is-npu-or-dpu.sh $FILESYSTEM_ROOT/usr/lo
 sudo cp $IMAGE_CONFIGS/midplane-network/define-npu-specific-netdevs.sh $FILESYSTEM_ROOT/usr/local/bin/
 
 # Copy midplane network service file for smart switch
-sudo cp $IMAGE_CONFIGS/midplane-network/bridge-midplane.netdev $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/bridge-midplane.netdev
+sudo cp $IMAGE_CONFIGS/midplane-network/bridge-midplane.netdev $FILESYSTEM_ROOT/usr/share/sonic/templates/bridge-midplane.netdev
 sudo cp $IMAGE_CONFIGS/midplane-network/bridge-midplane.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/bridge-midplane.network
-sudo cp $IMAGE_CONFIGS/midplane-network/dummy-midplane.netdev $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/dummy-midplane.netdev
+sudo cp $IMAGE_CONFIGS/midplane-network/dummy-midplane.netdev $FILESYSTEM_ROOT/usr/share/sonic/templates/dummy-midplane.netdev
 sudo cp $IMAGE_CONFIGS/midplane-network/dummy-midplane.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/dummy-midplane.network
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-npu.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/midplane-network-npu.network
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-dpu.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/midplane-network-dpu.network

--- a/files/image_config/midplane-network/is-npu-or-dpu.sh
+++ b/files/image_config/midplane-network/is-npu-or-dpu.sh
@@ -25,11 +25,11 @@ HAS_NPU=0
 
 if [[ -f /usr/share/sonic/device/${PLATFORM}/platform.json ]]; then
     if jq -e '.DPUS' /usr/share/sonic/device/${PLATFORM}/platform.json >/dev/null; then
-        HAS_DPU=1
+        HAS_NPU=1
     fi
 
     if jq -e '.DPU' /usr/share/sonic/device/${PLATFORM}/platform.json >/dev/null; then
-        HAS_NPU=1
+        HAS_DPU=1
     fi
 fi
 

--- a/files/image_config/midplane-network/systemd-networkd.override.conf
+++ b/files/image_config/midplane-network/systemd-networkd.override.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecCondition=/bin/bash /usr/local/bin/is-npu-or-dpu.sh
-ExecStartPre=/bin/bash /usr/local/bin/define-npu-specific-netdevs.sh
+ExecStartPre=+/bin/bash /usr/local/bin/define-npu-specific-netdevs.sh


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
netdev files are not available at /usr/share/sonic/templates. 

#### How I did it
Copy these files to this directory.

#### How to verify it
On NPU these netdevs should be present

#### A picture of a cute animal (not mandatory but encouraged)

