### PR TITLE
[#24386] rsyslog: restore kernel timestamp in the /dev/kmsg logs

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -30,6 +30,9 @@ $SystemLogRateLimitBurst {{ rate_limit_burst }}
 {% endif %}
 
 $ModLoad imklog   # provides kernel logging support
+$KlogParseKernelTimestamp off
+$KlogKeepKernelTimestamp on
+
 #$ModLoad immark  # provides --MARK-- message capability
 
 # provides UDP syslog reception


### PR DESCRIPTION
The `imklog` plugin of rsyslog collects the kernel logs from `/dev/kmsg` and enqueues it to the syslog. With `CONFIG_PRINTK_TIME` the kernel messages are by default prefixed with the elapsed time since boot. The `imklog` plugin parsing these messages have a few options such as to keep the timestamps as such or to interpret and adjust the syslog's reported time accordingly.

The rsylog release `8.2312.0` has fixes in interpreting these timestamps, leading to the change in behavior observed in #24386.

  https://salsa.debian.org/debian/rsyslog/-/blob/debian/8.2504.0-1/ChangeLog?ref_type=tags#L619

To restore the earlier behavior or retaining the kernel reported elapsed time, disable `KlogParseKernelTimestamp` as this leads to removal of timestamp from kernel messages and enable `KlogKeepKernelTimestamp` explicitly. The later is required as the default is now to discard the kernel timestamp.

With this change, the logs retain the kernel timestamp:

    root@sonic:~# cat /var/log/syslog | grep "sonic.*kernel:" | head -n 3
    2025 Nov  4 05:15:14.918946 sonic NOTICE kernel: [    0.000000] Linux version 6.12.41+deb13-sonic-amd64 (debian-kernel@lists.debian.org) (x86_64-linux-gnu-gcc-14 (Debian 14.2.0-19) 14.2.0, GNU ld (GNU Binutils for Debian) 2.44) #1 SMP PREEMPT_DYNAMIC Debian 6.12.41-1 (2025-08-12)
    2025 Nov  4 05:15:14.919533 sonic INFO kernel: [    0.000000] Command line: BOOT_IMAGE=/image-trixie.0-dirty-20251102.122837/boot/vmlinuz-6.12.41+deb13-sonic-amd64 root=UUID=ac0b6826-f8a3-461f-a8ff-701df60d90b6 rw console=tty0 console=ttyS0,115200n8 quiet processor.max_cstate=1 intel_idle.max_cstate=0 net.ifnames=0 biosdevname=0 loop=image-trixie.0-dirty-20251102.122837/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 intel_iommu=off modprobe.blacklist=gpio_ich,i2c-ismt,i2c_ismt,i2c-i801,i2c_i801 crashkernel=0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M acpi_no_watchdog
    2025 Nov  4 05:15:14.919536 sonic INFO kernel: [    0.000000] BIOS-provided physical RAM map:
    root@sonic:~# cat /var/log/syslog | grep "sonic.*kernel:" | tail -n 3
    2025 Nov  4 05:17:26.831607 sonic WARNING kernel: [  143.527486] PDDF_LED       set_status_led: Set [FANTRAY_LED;1] color[green]
    2025 Nov  4 05:17:26.912442 sonic WARNING kernel: [  143.607086] PDDF_LED       set_status_led: Set [FANTRAY_LED;2] color[green]
    2025 Nov  4 05:20:32.499634 sonic WARNING kernel: [  329.195319] PDDF_LED       set_status_led: Set [SYS_LED;0] color[amber]
    root@sonic:~#

Signed-off-by: Ramasamy Chandramouli <rachandr@celestica.com>