### PR TITLE
Fix copying netdevs on npu

### DIFF
--- a/files/image_config/midplane-network/define-npu-specific-netdevs.sh
+++ b/files/image_config/midplane-network/define-npu-specific-netdevs.sh
@@ -3,6 +3,6 @@
 set -e
 
 if /bin/bash /usr/local/bin/is-npu-or-dpu.sh -n; then
-    cp /usr/share/sonic/templates/bridge-midplane.netdev /etc/systemd/network/
-    cp /usr/share/sonic/templates/dummy-midplane.netdev /etc/systemd/network/
+    cp --remove-destination /usr/share/sonic/templates/bridge-midplane.netdev /etc/systemd/network/
+    cp --remove-destination /usr/share/sonic/templates/dummy-midplane.netdev /etc/systemd/network/
 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The copy didn't work because the existing files are symlinks to /dev/null. And cp will open the files and write the contents to /dev/null. Forcing to remove existing files i.e symlinks will help copy the netdev files to the destination.

#### How to verify it
netdevs must be created on a smartswitch


PS:
1. You might run into weird issues if this fix isn't present - for instance your tty console being blocked and something as fundamental as systemd-udevd not starting. 


#### A picture of a cute animal (not mandatory but encouraged)
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/3c7659ca-0d3c-4640-ae0f-54e5c8f467ff" />

