### PR TITLE
Fix system health checker on Debian 13.

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -48,13 +48,9 @@ class ServiceChecker(HealthChecker):
     CHECK_CMD = 'monit summary -B'
     MIN_CHECK_CMD_LINES = 3
 
-    # Expect status for different system service category.
-    EXPECT_STATUS_DICT = {
-        'System': 'Running',
-        'Process': 'Running',
-        'Filesystem': 'Accessible',
-        'Program': 'Status ok'
-    }
+    # Expect status for all system service categories.
+    # Monit 5.34.3+ (Debian 13) uses 'OK' for all service types
+    EXPECTED_STATUS = 'OK'
 
     def __init__(self):
         HealthChecker.__init__(self)
@@ -290,11 +286,8 @@ class ServiceChecker(HealthChecker):
                 continue
             status = line[status_begin:type_begin].strip()
             service_type = line[type_begin:].strip()
-            if service_type not in ServiceChecker.EXPECT_STATUS_DICT:
-                continue
-            expect_status = ServiceChecker.EXPECT_STATUS_DICT[service_type]
-            if expect_status != status:
-                self.set_object_not_ok(service_type, name, '{} is not {}'.format(name, expect_status))
+            if status != ServiceChecker.EXPECTED_STATUS:
+                self.set_object_not_ok(service_type, name, '{} status is {}, expected {}'.format(name, status, ServiceChecker.EXPECTED_STATUS))
             else:
                 self.set_object_ok(service_type, name)
         return


### PR DESCRIPTION
Monit 5.34.3+ on Debian 13 changes the output format of monit. This commit modifies the parsing logic

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On Debian 13

```
root@sonic:/home/admin# monit summary -B
Monit 5.34.3 uptime: 33m
 Service Name                     Status                      Type
 sonic                            OK                          System
 rsyslog                          OK                          Process
 root-overlay                     OK                          Filesystem
 var-log                          OK                          Filesystem
 routeCheck                       OK                          Program
 dualtorNeighborCheck             OK                          Program
 diskCheck                        OK                          Program
 container_checker                OK                          Program
 vnetRouteCheck                   OK                          Program
 memory_check                     OK                          Program
 arp_update_checker               OK                          Program
 controlPlaneDropCheck            OK                          Program
 mgmtOperStatus                   OK                          Program
 container_memory_snmp            OK                          Program
 container_memory_gnmi            OK                          Program
 container_eventd                 OK                          Program
 container_memory_bmp             OK                          Program

```

vs Previously on Debian 12

```
root@sonic:/home/admin# monit summary -B
Monit 5.20.0 uptime: 10h 48m
 Service Name                     Status                      Type
 sonic                    Running                     System
 rsyslog                          Running                     Process
 root-overlay                     Accessible                  Filesystem
 var-log                          Accessible                  Filesystem
 routeCheck                       Status ok                   Program
 dualtorNeighborCheck             Status ok                   Program
 diskCheck                        Status ok                   Program
 container_checker                Status ok                   Program
 vnetRouteCheck                   Status ok                   Program
 memory_check                     Status ok                   Program
 arp_update_checker               Status ok                   Program
 controlPlaneDropCheck            Status ok                   Program
 mgmtOperStatus                   Status ok                   Program
 container_memory_snmp            Status ok                   Program
 container_memory_gnmi            Status ok                   Program
 container_eventd                 Status ok                   Program
 container_memory_bmp             Status ok                   Program
```
#### How I did it
Modified the output parsing logic in the system health service

#### How to verify it
`show system-health summary` should be All OK
