### PR TITLE
[Trixie][Ufispace] Update platform-modules-ufispace for Trixie

### DIFF
--- a/device/ufispace/x86_64-ufispace_s6301_56st-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s6301_56st-r0/pddf/pddf-device.json
@@ -36,7 +36,7 @@
             "lm75",
             "gpio-pca953x",
             "ucd9000",
-            "eeprom"
+            "at24"
         ],
         "pddf_kos": [
             "pddf_client_module",
@@ -906,7 +906,7 @@
                 "attr_list": [
                     {
                         "attr_name": "psu_present",
-                        "bmc_cmd": "i2cget -y -f 2 0x58 0x0 > /dev/null 2>&1; [ $? -ne 0 ] && echo '0' || echo '1'",
+                        "bmc_cmd": "[ -n \"$(cat /sys/bus/i2c/devices/2-0058/psu_mfr_id | tr -d '\n')\" ] && echo '1' || echo '0'",
                         "raw": "1",
                         "type": "raw"
                     }
@@ -1071,7 +1071,7 @@
             "topo_info":{
                 "parent_bus":"0x2",
                 "dev_addr":"0x50",
-                "dev_type":"eeprom"
+                "dev_type":"24c02"
             },
             "attr_list":
             [
@@ -1100,7 +1100,7 @@
                 "attr_list": [
                     {
                         "attr_name": "psu_present",
-                        "bmc_cmd": "i2cget -y -f 2 0x59 0x0 > /dev/null 2>&1; [ $? -ne 0 ] && echo '0' || echo '1'",
+                        "bmc_cmd": "[ -n \"$(cat /sys/bus/i2c/devices/2-0059/psu_mfr_id | tr -d '\n')\" ] && echo '1' || echo '0'",
                         "raw": "1",
                         "type": "raw"
                     }
@@ -1265,7 +1265,7 @@
             "topo_info":{
                 "parent_bus":"0x2",
                 "dev_addr":"0x51",
-                "dev_type":"eeprom"
+                "dev_type":"24c02"
             },
             "attr_list":
             [

--- a/device/ufispace/x86_64-ufispace_s9300_32d-r0/installer.conf
+++ b/device/ufispace/x86_64-ufispace_s9300_32d-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx nomodeset pcie_aspm=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx,i2c_i801 nomodeset pcie_aspm=off"

--- a/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pddf-device.json
@@ -21,7 +21,8 @@
         },
         "std_perm_kos": [
             "igb",
-            "i40e"
+            "i40e",
+            "x86-64-ufispace-s9300-32d-i2c-smbus"
         ],
         "std_kos": [
             "i2c_i801",

--- a/device/ufispace/x86_64-ufispace_s9301_32d-r0/installer.conf
+++ b/device/ufispace/x86_64-ufispace_s9301_32d-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx nomodeset pcie_aspm=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx,i2c_i801 nomodeset pcie_aspm=off"

--- a/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pddf-device.json
@@ -21,7 +21,8 @@
         },
         "std_perm_kos": [
             "igb",
-            "i40e"
+            "i40e",
+            "x86-64-ufispace-s9301-32d-i2c-smbus"
         ],
         "std_kos": [
             "i2c_i801",

--- a/device/ufispace/x86_64-ufispace_s9301_32db-r0/installer.conf
+++ b/device/ufispace/x86_64-ufispace_s9301_32db-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx nomodeset pcie_aspm=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=i40e,gpio_ich,qat_c3xxx,i2c_i801 nomodeset pcie_aspm=off"

--- a/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pddf-device.json
@@ -21,7 +21,8 @@
         },
         "std_perm_kos": [
             "igb",
-            "i40e"
+            "i40e",
+            "x86-64-ufispace-s9301-32db-i2c-smbus"
         ],
         "std_kos": [
             "i2c_i801",

--- a/device/ufispace/x86_64-ufispace_s9321_64e-r0/installer.conf
+++ b/device/ufispace/x86_64-ufispace_s9321_64e-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=gpio_ich,qat_c3xxx,i2c_ismt,ice,vmd nomodeset pcie_aspm=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=gpio_ich,qat_c3xxx,i2c_ismt,ice,vmd,i2c_i801 nomodeset pcie_aspm=off"

--- a/device/ufispace/x86_64-ufispace_s9321_64e-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9321_64e-r0/pddf/pddf-device.json
@@ -23,6 +23,7 @@
             ]
         },
         "std_perm_kos": [
+            "x86-64-ufispace-s9321-64e-i2c-smbus",
             "i2c-i801"
         ],
         "std_kos": [

--- a/device/ufispace/x86_64-ufispace_s9321_64eo-r0/installer.conf
+++ b/device/ufispace/x86_64-ufispace_s9321_64eo-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=gpio_ich,qat_c3xxx,i2c_ismt,ice,vmd nomodeset pcie_aspm=off"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=gpio_ich,qat_c3xxx,i2c_ismt,ice,vmd,i2c_i801 nomodeset pcie_aspm=off"

--- a/device/ufispace/x86_64-ufispace_s9321_64eo-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9321_64eo-r0/pddf/pddf-device.json
@@ -23,6 +23,7 @@
             ]
         },
         "std_perm_kos": [
+            "x86-64-ufispace-s9321-64eo-i2c-smbus",
             "i2c-i801"
         ],
         "std_kos": [

--- a/platform/broadcom/rules.dep
+++ b/platform/broadcom/rules.dep
@@ -17,7 +17,7 @@ include $(PLATFORM_PATH)/platform-modules-cel.dep
 #include $(PLATFORM_PATH)/platform-modules-brcm-xlr-gts.dep
 #include $(PLATFORM_PATH)/platform-modules-ruijie.dep
 #include $(PLATFORM_PATH)/platform-modules-ragile.dep
-#include $(PLATFORM_PATH)/platform-modules-ufispace.dep
+include $(PLATFORM_PATH)/platform-modules-ufispace.dep
 #include $(PLATFORM_PATH)/platform-modules-micas.dep
 include $(PLATFORM_PATH)/docker-syncd-brcm.dep
 include $(PLATFORM_PATH)/docker-syncd-brcm-rpc.dep

--- a/platform/broadcom/rules.mk
+++ b/platform/broadcom/rules.mk
@@ -19,7 +19,7 @@ include $(PLATFORM_PATH)/platform-modules-cel.mk
 #include $(PLATFORM_PATH)/platform-modules-ruijie.mk
 #include $(PLATFORM_PATH)/platform-modules-ragile.mk
 #include $(PLATFORM_PATH)/platform-modules-tencent.mk
-#include $(PLATFORM_PATH)/platform-modules-ufispace.mk
+include $(PLATFORM_PATH)/platform-modules-ufispace.mk
 #include $(PLATFORM_PATH)/platform-modules-micas.mk
 include $(PLATFORM_PATH)/docker-syncd-brcm.mk
 include $(PLATFORM_PATH)/docker-syncd-brcm-rpc.mk

--- a/platform/broadcom/sonic-platform-modules-ufispace/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-ufispace/debian/rules
@@ -13,11 +13,14 @@ include /usr/share/dpkg/pkg-info.mk
 
 export INSTALL_MOD_DIR:=extra
 
-PYTHON3     ?= python3
+ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+    NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+    MAKE_FLAGS += -j$(NUMJOBS)
+endif
 
 PACKAGE_PRE_NAME := sonic-platform-ufispace
 KVERSION   ?= $(shell uname -r)
-KERNEL_SRC :=  /lib/modules/$(KVERSION)
+export KERNEL_SRC :=  /lib/modules/$(KVERSION)
 MOD_SRC_DIR:= $(shell pwd)
 MODULE_DIRS := s9300-32d
 MODULE_DIRS += s9301-32d
@@ -34,63 +37,54 @@ SERVICE_DIR := service
 CONF_DIR := conf
 
 %:
-	dh $@ --with systemd,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
-clean:
-	dh_testdir
-	dh_testroot
-	dh_clean
-	(for mod in $(MODULE_DIRS); do \
-	    make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
-	done)
-
-
-
-build:
-	(for mod in $(MODULE_DIRS); do \
-		make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
-		cd -; \
-		cd $(MOD_SRC_DIR)/$${mod}; \
-		if [ -f sonic_platform_setup.py ]; then \
-			$(PYTHON3) sonic_platform_setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}; \
-			echo "Finished makig whl package for $$mod"; \
+override_dh_auto_clean:
+	(set -e; for mod in $(MODULE_DIRS); do \
+		$(MAKE) clean -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
+		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
+			PYBUILD_NAME=$${mod} pybuild --clean -d $${mod}; \
 		fi; \
-                cd -; \
+	done)
+	dh_clean
+
+override_dh_auto_configure:
+	(set -e; for mod in $(MODULE_DIRS); do \
+		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
+			PYBUILD_NAME=$${mod} pybuild --configure -d $${mod}; \
+		fi; \
 	done)
 
-binary: binary-arch binary-indep
+override_dh_auto_build:
+	(set -e; for mod in $(MODULE_DIRS); do \
+		$(MAKE) $(MAKE_FLAGS) -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules modules; \
+		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
+			PYBUILD_NAME=$${mod} pybuild --build -d $${mod}; \
+		fi; \
+		if [ -d $(MOD_SRC_DIR)/$${mod}/pddf ]; then \
+			cd $(MOD_SRC_DIR)/$${mod}/pddf; \
+			if [ -f sonic_platform_setup.py ]; then \
+				python3 sonic_platform_setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/pddf; \
+				echo "Finished making pddf whl package for $$mod"; \
+			fi; \
+			cd $(MOD_SRC_DIR); \
+		fi; \
+	done)
 
-binary-arch:
+override_dh_usrlocal:
+	# Ignore making directories
 
-binary-indep:
-	dh_testdir
-	dh_installdirs
-	(for mod in $(MODULE_DIRS); do \
-		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} $(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
-		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
+override_dh_auto_test:
+	# No tests to run
+
+override_dh_auto_install:
+	(set -e; for mod in $(MODULE_DIRS); do \
+		$(MAKE) -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules INSTALL_MOD_PATH=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} modules_install; \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} usr/local/bin; \
-		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin; \
+		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} lib/systemd/system; \
-		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system; \
-		cd $(MOD_SRC_DIR)/$${mod}; \
-		cd -; \
+		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
+		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
+			PYBUILD_NAME=$${mod} pybuild --install -d $${mod} --dest-dir debian/$(PACKAGE_PRE_NAME)-$${mod}; \
+		fi; \
 	done)
-
-	# Resuming debhelper scripts
-	dh_testroot
-	dh_install
-	dh_installchangelogs
-	dh_installdocs
-	dh_systemd_enable
-	dh_installinit
-	dh_systemd_start
-	dh_link
-	dh_fixperms
-	dh_compress
-	dh_strip
-	dh_installdeb
-	dh_gencontrol
-	dh_md5sums
-	dh_builddeb
-
-.PHONY: build binary binary-arch binary-indep clean

--- a/platform/broadcom/sonic-platform-modules-ufispace/s6301-56st/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s6301-56st/modules/pddf_custom_psu.c
@@ -82,7 +82,6 @@ static u16 psu_get_v_out(struct i2c_client *client)
 ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *da, char *buf)
 {
   struct i2c_client *client = to_i2c_client(dev);
-  struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
   int exponent, mantissa;
   int multiplier = 1000;
 

--- a/platform/broadcom/sonic-platform-modules-ufispace/s6301-56st/modules/x86-64-ufispace-s6301-56st-sys-eeprom.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s6301-56st/modules/x86-64-ufispace-s6301-56st-sys-eeprom.c
@@ -17,7 +17,7 @@
  */
 
 /* enable dev_dbg print out */
-//#define DEBUG 
+//#define DEBUG
 
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <linux/kernel.h>
@@ -89,7 +89,7 @@ static void sys_eeprom_update_client(struct i2c_client *client, u8 slice)
                 data->data[j] = res & 0xFF;
             }
         }
-        
+
         data->last_updated[slice] = jiffies;
         data->valid |= (1 << slice);
     }
@@ -105,7 +105,7 @@ static ssize_t sys_eeprom_read(struct file *filp, struct kobject *kobj,
     struct eeprom_data *data = i2c_get_clientdata(client);
     u8 slice;
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -138,7 +138,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
 
     dev_dbg(&client->dev, "sys_eeprom_write off=%d, count=%d\n", (int)off, (int)count);
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -163,7 +163,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
         }
 
         off++;
-        
+
         /* need to wait for write complete */
         udelay(10000);
     }
@@ -195,22 +195,36 @@ static int sys_eeprom_detect(struct i2c_client *client, struct i2c_board_info *i
     /* EDID EEPROMs are often 24C00 EEPROMs, which answer to all
        addresses 0x50-0x57, but we only care about 0x51 and 0x55. So decline
        attaching to addresses >= 0x56 on DDC buses */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
     if (!(adapter->class & I2C_CLASS_SPD) && client->addr >= 0x56) {
         return -ENODEV;
     }
+#else
+    if (client->addr >= 0x56) {
+        return -ENODEV;
+    }
+#endif
 
     if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_READ_BYTE)
      && !i2c_check_functionality(adapter, I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
         return -ENODEV;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     strlcpy(info->type, "eeprom", I2C_NAME_SIZE);
+#else
+    strscpy(info->type, "eeprom", I2C_NAME_SIZE);
+#endif
 
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int sys_eeprom_probe(struct i2c_client *client,
             const struct i2c_device_id *id)
+#else
+static int sys_eeprom_probe(struct i2c_client *client)
+#endif
 {
     struct eeprom_data *data;
     int err;
@@ -271,7 +285,13 @@ static struct i2c_driver sys_eeprom_driver = {
     .remove     = sys_eeprom_remove,
     .id_table   = sys_eeprom_id,
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     .class      = I2C_CLASS_DDC | I2C_CLASS_SPD,
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+    .class      = I2C_CLASS_SPD,
+#else
+    .class      = 0,
+#endif
     .detect     = sys_eeprom_detect,
     .address_list   = normal_i2c,
 };

--- a/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/x86-64-ufispace-s7801-54xs-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/x86-64-ufispace-s7801-54xs-cpld.c
@@ -1,7 +1,7 @@
 /*
  * A i2c cpld driver for the ufispace_s7801_54xs
  *
- * Copyright (C) 2017-2022 UfiSpace Technology Corporation.
+ * Copyright (C) 2025 UfiSpace Technology Corporation.
  * Jason Tsai <jason.cy.tsai@ufispace.com>
  *
  * Based on ad7414.c
@@ -922,6 +922,8 @@ static struct attribute *cpld2_attributes[] = {
     NULL
 };
 
+int s7801_54xs_cpld_psu_mux_sel(u8) ;
+
 /* cpld 1 attributes group */
 static const struct attribute_group cpld1_group = {
     .attrs = cpld1_attributes,
@@ -1244,9 +1246,15 @@ static void cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct cpld_data *data = NULL;
     int ret = -EPERM;
@@ -1334,11 +1342,10 @@ exit:
 
 /* cpld drvier remove */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
-static int
+static int cpld_remove(struct i2c_client *client)
 #else
-static void
+static void cpld_remove(struct i2c_client *client)
 #endif
-cpld_remove(struct i2c_client *client)
 {
     struct cpld_data *data = i2c_get_clientdata(client);
 
@@ -1514,6 +1521,7 @@ static void __exit cpld_exit(void)
 
 MODULE_AUTHOR("Jason Tsai <jason.cy.tsai@ufispace.com>");
 MODULE_DESCRIPTION("x86_64_ufispace_s7801_54xs_cpld driver");
+MODULE_VERSION("1.0.1");
 MODULE_LICENSE("GPL");
 
 module_init(cpld_init);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/x86-64-ufispace-s7801-54xs-cpld.h
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s7801-54xs/modules/x86-64-ufispace-s7801-54xs-cpld.h
@@ -18,8 +18,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef UFISPACE_s7801_54xs_CPLD_H
-#define UFISPACE_s7801_54xs_CPLD_H
+#ifndef UFISPACE_S7801_54XS_CPLD_H
+#define UFISPACE_S7801_54XS_CPLD_H
 
 /* CPLD device index value */
 enum cpld_id {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s8901-54xc/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s8901-54xc/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s8901-54xc/modules/x86-64-ufispace-s8901-54xc-cpld.h
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s8901-54xc/modules/x86-64-ufispace-s8901-54xc-cpld.h
@@ -49,6 +49,7 @@ enum cpld_id {
 #define CPLD_CPU_NMI_INTR_REG             0x19
 #define CPLD_PTP_INTR_REG                 0x1B
 #define CPLD_SYSTEM_INTR_REG              0x1C
+#define CPLD_RESET_BTN_INTR_REG           0x1F
 
 #define CPLD_MAC_MASK_REG                 0x20
 #define CPLD_HWM_MASK_REG                 0x23
@@ -249,6 +250,7 @@ enum cpld_id {
 #define MASK_LB                            (0b00001111)
 #define MASK_CPLD_MAJOR_VER                (0b11000000)
 #define MASK_CPLD_MINOR_VER                (0b00111111)
+#define MASK_CPLD_RESET_BTN_INTR           (0b10000000)
 #define CPLD_SYSTEM_LED_SYS_MASK           MASK_HB
 #define CPLD_SYSTEM_LED_FAN_MASK           MASK_LB
 #define CPLD_SYSTEM_LED_PSU_0_MASK         MASK_LB

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/x86-64-ufispace-s9110-32x-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/x86-64-ufispace-s9110-32x-cpld.c
@@ -1235,9 +1235,15 @@ static void cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct cpld_data *data = NULL;
     int ret = -EPERM;

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/x86-64-ufispace-s9110-32x-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9110-32x/modules/x86-64-ufispace-s9110-32x-lpc.c
@@ -27,6 +27,7 @@
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/gpio.h>
+#include <linux/version.h>
 
 #if !defined(SENSOR_DEVICE_ATTR_RO)
 #define SENSOR_DEVICE_ATTR_RO(_name, _func, _index)		\
@@ -141,6 +142,7 @@ enum lpc_sysfs_attributes {
     ATT_BSP_REG,
     ATT_BSP_REG_VALUE,
     ATT_BSP_GPIO_MAX,
+    ATT_BSP_GPIO_BASE,
     ATT_MAX
 };
 
@@ -197,6 +199,7 @@ attr_reg_map_t attr_reg[]= {
     [ATT_BSP_REG]             = {REG_NONE         , MASK_NONE     , DATA_UNK},
     [ATT_BSP_REG_VALUE]       = {REG_NONE         , MASK_NONE     , DATA_HEX},
     [ATT_BSP_GPIO_MAX]        = {REG_NONE         , MASK_NONE     , DATA_DEC},
+    [ATT_BSP_GPIO_BASE]       = {REG_NONE         , MASK_NONE     , DATA_DEC},
 };
 
 enum bsp_log_types {
@@ -224,6 +227,9 @@ u8 enable_log_read  = LOG_DISABLE;
 u8 enable_log_write = LOG_DISABLE;
 u8 enable_log_sys   = LOG_ENABLE;
 u8 mailbox_inited=0;
+
+int lpc_init(void);
+void lpc_exit(void);
 
 /* reg shift */
 static u8 _shift(u8 mask)
@@ -472,12 +478,33 @@ static ssize_t gpio_max_show(struct device *dev,
                     struct device_attribute *da,
                     char *buf)
 {
-    u8 data_type=DATA_UNK;
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
 
     if (attr->index == ATT_BSP_GPIO_MAX) {
-        data_type = attr_reg[attr->index].data_type;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        u8 data_type = attr_reg[attr->index].data_type;
         return _parse_data(buf, ARCH_NR_GPIOS-1, data_type);
+#else
+        return sprintf(buf, "%d\n", -1);
+#endif
+    }
+    return -1;
+}
+
+/* get gpio base value */
+static ssize_t gpio_base_show(struct device *dev,
+                    struct device_attribute *da,
+                    char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_BASE) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        return sprintf(buf, "%d\n", -1);
+#else
+        u8 data_type = attr_reg[attr->index].data_type;
+        return _parse_data(buf, GPIO_DYNAMIC_BASE, data_type);
+#endif
     }
     return -1;
 }
@@ -547,6 +574,7 @@ static ssize_t lpc_callback_show(struct device *dev,
 
         //BSP
         case ATT_BSP_GPIO_MAX:
+        case ATT_BSP_GPIO_BASE:
             reg = attr_reg[attr->index].reg;
             mask= attr_reg[attr->index].mask;
             data_type = attr_reg[attr->index].data_type;
@@ -772,6 +800,7 @@ static SENSOR_DEVICE_ATTR_WO(bsp_pr_err          , bsp_pr_callback  , ATT_BSP_PR
 static SENSOR_DEVICE_ATTR_RW(bsp_reg             , bsp_callback     , ATT_BSP_REG);
 static SENSOR_DEVICE_ATTR_RO(bsp_reg_value       , lpc_callback     , ATT_BSP_REG_VALUE);
 static SENSOR_DEVICE_ATTR_RO(bsp_gpio_max        , gpio_max         , ATT_BSP_GPIO_MAX);
+static SENSOR_DEVICE_ATTR_RO(bsp_gpio_base       , gpio_base        , ATT_BSP_GPIO_BASE);
 
 static struct attribute *mb_cpld_attrs[] = {
     _DEVICE_ATTR(board_id_0),
@@ -818,6 +847,7 @@ static struct attribute *bsp_attrs[] = {
     _DEVICE_ATTR(bsp_reg),
     _DEVICE_ATTR(bsp_reg_value),
     _DEVICE_ATTR(bsp_gpio_max),
+    _DEVICE_ATTR(bsp_gpio_base),
     NULL,
 };
 
@@ -926,14 +956,19 @@ exit:
     }
     return 0;
 }
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int lpc_drv_remove(struct platform_device *pdev)
+#else
+static void lpc_drv_remove(struct platform_device *pdev)
+#endif
 {
     sysfs_remove_group(&pdev->dev.kobj, &mb_cpld_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bsp_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &ec_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bmc_mailbox_attr_grp);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver lpc_drv = {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/Makefile
@@ -1,5 +1,5 @@
 
-MODULE_NAME  = x86-64-ufispace-s9300-32d-cpld.o x86-64-ufispace-s9300-32d-sys-eeprom.o x86-64-ufispace-s9300-32d-lpc.o pddf_custom_sysstatus_module.o 
+MODULE_NAME  = x86-64-ufispace-s9300-32d-cpld.o x86-64-ufispace-s9300-32d-sys-eeprom.o x86-64-ufispace-s9300-32d-lpc.o pddf_custom_sysstatus_module.o x86-64-ufispace-s9300-32d-i2c-smbus.o
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-cpld.c
@@ -438,31 +438,31 @@ static SENSOR_DEVICE_ATTR(cpld_qsfpdd_reset_ctrl_g0, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_RESET_CTRL_G0);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_reset_ctrl_g1, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_RESET_CTRL_G1);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_reset_ctrl_g2, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_RESET_CTRL_G2);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_reset_ctrl_g3, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_RESET_CTRL_G3);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_lp_mode_g0, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_LP_MODE_G0);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_lp_mode_g1, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_LP_MODE_G1);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_lp_mode_g2, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_LP_MODE_G2);
 static SENSOR_DEVICE_ATTR(cpld_qsfpdd_lp_mode_g3, \
-	    S_IWUSR | S_IRUGO, \
+        S_IWUSR | S_IRUGO, \
         read_cpld_callback, write_cpld_callback, \
         CPLD_QSFPDD_LP_MODE_G3);
 static SENSOR_DEVICE_ATTR(cpld_sfp_tx_dis, S_IWUSR | S_IRUGO, \
@@ -1435,9 +1435,15 @@ static void s9300_cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int s9300_cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int s9300_cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct cpld_data *data = NULL;
     int ret = -EPERM;

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-i2c-smbus.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-i2c-smbus.c
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * i2c-smbus.c - SMBus extensions to the I2C protocol
+ *
+ * Copyright (C) 2008 David Brownell
+ * Copyright (C) 2010-2019 Jean Delvare <jdelvare@suse.de>
+ *
+ * In kernel 6.12.41, the system EEPROM (located on i801 bus, address 0) is misrecognized as an SPD.
+ * Since no standard method is available to resolve this conflict, this patch implements a workaround.
+ * 
+ */
+
+#include <linux/device.h>
+#include <linux/dmi.h>
+#include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/version.h>
+
+static int disable_i2c_register_spd = 1;
+module_param(disable_i2c_register_spd, int, 0);
+
+struct i2c_smbus_alert {
+	struct work_struct	alert;
+	struct i2c_client	*ara;		/* Alert response address */
+};
+
+struct alert_data {
+	unsigned short		addr;
+	enum i2c_alert_protocol	type;
+	unsigned int		data;
+};
+
+/* If this is the alerting device, notify its driver */
+static int smbus_do_alert(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+	int ret;
+
+	if (!client || client->addr != data->addr)
+		return 0;
+	if (client->flags & I2C_CLIENT_TEN)
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler.  Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert) {
+			/* Stop iterating after we find the device */
+			driver->alert(client, data->type, data->data);
+			ret = -EBUSY;
+		} else {
+			dev_warn(&client->dev, "no driver alert()!\n");
+			ret = -EOPNOTSUPP;
+		}
+	} else {
+		dev_dbg(&client->dev, "alert with no driver\n");
+		ret = -ENODEV;
+	}
+	device_unlock(dev);
+
+	return ret;
+}
+
+/* Same as above, but call back all drivers with alert handler */
+
+static int smbus_do_alert_force(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+
+	if (!client || (client->flags & I2C_CLIENT_TEN))
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler. Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert)
+			driver->alert(client, data->type, data->data);
+	}
+	device_unlock(dev);
+
+	return 0;
+}
+
+/*
+ * The alert IRQ handler needs to hand work off to a task which can issue
+ * SMBus calls, because those sleeping calls can't be made in IRQ context.
+ */
+static irqreturn_t smbus_alert(int irq, void *d)
+{
+	struct i2c_smbus_alert *alert = d;
+	struct i2c_client *ara;
+	unsigned short prev_addr = I2C_CLIENT_END; /* Not a valid address */
+
+	ara = alert->ara;
+
+	for (;;) {
+		s32 status;
+		struct alert_data data;
+
+		/*
+		 * Devices with pending alerts reply in address order, low
+		 * to high, because of slave transmit arbitration.  After
+		 * responding, an SMBus device stops asserting SMBALERT#.
+		 *
+		 * Note that SMBus 2.0 reserves 10-bit addresses for future
+		 * use.  We neither handle them, nor try to use PEC here.
+		 */
+		status = i2c_smbus_read_byte(ara);
+		if (status < 0)
+			break;
+
+		data.data = status & 1;
+		data.addr = status >> 1;
+		data.type = I2C_PROTOCOL_SMBUS_ALERT;
+
+		dev_dbg(&ara->dev, "SMBALERT# from dev 0x%02x, flag %d\n",
+			data.addr, data.data);
+
+		/* Notify driver for the device which issued the alert */
+		status = device_for_each_child(&ara->adapter->dev, &data,
+					       smbus_do_alert);
+		/*
+		 * If we read the same address more than once, and the alert
+		 * was not handled by a driver, it won't do any good to repeat
+		 * the loop because it will never terminate. Try again, this
+		 * time calling the alert handlers of all devices connected to
+		 * the bus, and abort the loop afterwards. If this helps, we
+		 * are all set. If it doesn't, there is nothing else we can do,
+		 * so we might as well abort the loop.
+		 * Note: This assumes that a driver with alert handler handles
+		 * the alert properly and clears it if necessary.
+		 */
+		if (data.addr == prev_addr && status != -EBUSY) {
+			device_for_each_child(&ara->adapter->dev, &data,
+					      smbus_do_alert_force);
+			break;
+		}
+		prev_addr = data.addr;
+	}
+
+	return IRQ_HANDLED;
+}
+
+static void smbalert_work(struct work_struct *work)
+{
+	struct i2c_smbus_alert *alert;
+
+	alert = container_of(work, struct i2c_smbus_alert, alert);
+
+	smbus_alert(0, alert);
+
+}
+
+/* Setup SMBALERT# infrastructure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int smbalert_probe(struct i2c_client *ara,
+			const struct i2c_device_id *dev_id)
+{
+#else
+static int smbalert_probe(struct i2c_client *ara)
+{
+#endif
+	struct i2c_smbus_alert_setup *setup = dev_get_platdata(&ara->dev);
+	struct i2c_smbus_alert *alert;
+	struct i2c_adapter *adapter = ara->adapter;
+	int res, irq;
+
+	alert = devm_kzalloc(&ara->dev, sizeof(struct i2c_smbus_alert),
+			     GFP_KERNEL);
+	if (!alert)
+		return -ENOMEM;
+
+	if (setup) {
+		irq = setup->irq;
+	} else {
+		irq = fwnode_irq_get_byname(dev_fwnode(adapter->dev.parent),
+					    "smbus_alert");
+		if (irq <= 0)
+			return irq;
+	}
+
+	INIT_WORK(&alert->alert, smbalert_work);
+	alert->ara = ara;
+
+	if (irq > 0) {
+		res = devm_request_threaded_irq(&ara->dev, irq,
+						NULL, smbus_alert,
+						IRQF_SHARED | IRQF_ONESHOT,
+						"smbus_alert", alert);
+		if (res)
+			return res;
+	}
+
+	i2c_set_clientdata(ara, alert);
+	dev_info(&adapter->dev, "supports SMBALERT#\n");
+
+	return 0;
+}
+
+/* IRQ and memory resources are managed so they are freed automatically */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int
+#else
+static void
+#endif
+smbalert_remove(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	cancel_work_sync(&alert->alert);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id smbalert_ids[] = {
+	{ "smbus_alert" },
+	{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, smbalert_ids);
+
+static struct i2c_driver smbalert_driver = {
+	.driver = {
+		.name	= "smbus_alert",
+	},
+	.probe		= smbalert_probe,
+	.remove		= smbalert_remove,
+	.id_table	= smbalert_ids,
+};
+
+/**
+ * i2c_handle_smbus_alert - Handle an SMBus alert
+ * @ara: the ARA client on the relevant adapter
+ * Context: can't sleep
+ *
+ * Helper function to be called from an I2C bus driver's interrupt
+ * handler. It will schedule the alert work, in turn calling the
+ * corresponding I2C device driver's alert function.
+ *
+ * It is assumed that ara is a valid i2c client previously returned by
+ * i2c_new_smbus_alert_device().
+ */
+int i2c_handle_smbus_alert(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	return schedule_work(&alert->alert);
+}
+EXPORT_SYMBOL_GPL(i2c_handle_smbus_alert);
+
+module_i2c_driver(smbalert_driver);
+
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+#define SMBUS_HOST_NOTIFY_LEN	3
+struct i2c_slave_host_notify_status {
+	u8 index;
+	u8 addr;
+};
+
+static int i2c_slave_host_notify_cb(struct i2c_client *client,
+				    enum i2c_slave_event event, u8 *val)
+{
+	struct i2c_slave_host_notify_status *status = client->dev.platform_data;
+
+	switch (event) {
+	case I2C_SLAVE_WRITE_RECEIVED:
+		/* We only retrieve the first byte received (addr)
+		 * since there is currently no support to retrieve the data
+		 * parameter from the client.
+		 */
+		if (status->index == 0)
+			status->addr = *val;
+		if (status->index < U8_MAX)
+			status->index++;
+		break;
+	case I2C_SLAVE_STOP:
+		if (status->index == SMBUS_HOST_NOTIFY_LEN)
+			i2c_handle_smbus_host_notify(client->adapter,
+						     status->addr);
+		fallthrough;
+	case I2C_SLAVE_WRITE_REQUESTED:
+		status->index = 0;
+		break;
+	case I2C_SLAVE_READ_REQUESTED:
+	case I2C_SLAVE_READ_PROCESSED:
+		*val = 0xff;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * i2c_new_slave_host_notify_device - get a client for SMBus host-notify support
+ * @adapter: the target adapter
+ * Context: can sleep
+ *
+ * Setup handling of the SMBus host-notify protocol on a given I2C bus segment.
+ *
+ * Handling is done by creating a device and its callback and handling data
+ * received via the SMBus host-notify address (0x8)
+ *
+ * This returns the client, which should be ultimately freed using
+ * i2c_free_slave_host_notify_device(); or an ERRPTR to indicate an error.
+ */
+struct i2c_client *i2c_new_slave_host_notify_device(struct i2c_adapter *adapter)
+{
+	struct i2c_board_info host_notify_board_info = {
+		I2C_BOARD_INFO("smbus_host_notify", 0x08),
+		.flags  = I2C_CLIENT_SLAVE,
+	};
+	struct i2c_slave_host_notify_status *status;
+	struct i2c_client *client;
+	int ret;
+
+	status = kzalloc(sizeof(struct i2c_slave_host_notify_status),
+			 GFP_KERNEL);
+	if (!status)
+		return ERR_PTR(-ENOMEM);
+
+	host_notify_board_info.platform_data = status;
+
+	client = i2c_new_client_device(adapter, &host_notify_board_info);
+	if (IS_ERR(client)) {
+		kfree(status);
+		return client;
+	}
+
+	ret = i2c_slave_register(client, i2c_slave_host_notify_cb);
+	if (ret) {
+		i2c_unregister_device(client);
+		kfree(status);
+		return ERR_PTR(ret);
+	}
+
+	return client;
+}
+EXPORT_SYMBOL_GPL(i2c_new_slave_host_notify_device);
+
+/**
+ * i2c_free_slave_host_notify_device - free the client for SMBus host-notify
+ * support
+ * @client: the client to free
+ * Context: can sleep
+ *
+ * Free the i2c_client allocated via i2c_new_slave_host_notify_device
+ */
+void i2c_free_slave_host_notify_device(struct i2c_client *client)
+{
+	if (IS_ERR_OR_NULL(client))
+		return;
+
+	i2c_slave_unregister(client);
+	kfree(client->dev.platform_data);
+	i2c_unregister_device(client);
+}
+EXPORT_SYMBOL_GPL(i2c_free_slave_host_notify_device);
+#endif
+
+/*
+ * SPD is not part of SMBus but we include it here for convenience as the
+ * target systems are the same.
+ * Restrictions to automatic SPD instantiation:
+ *  - Only works if all filled slots have the same memory type
+ *  - Only works for (LP)DDR memory types up to DDR5
+ *  - Only works on systems with 1 to 8 memory slots
+ */
+#if IS_ENABLED(CONFIG_DMI)
+void i2c_register_spd(struct i2c_adapter *adap)
+{
+	int n, slot_count = 0, dimm_count = 0;
+	u16 handle;
+	u8 common_mem_type = 0x0, mem_type;
+	u64 mem_size;
+	const char *name;
+
+	//disable spd scan to prevent address conflict between spd and sys eeprom
+	if (disable_i2c_register_spd == 1) {
+		return;
+	}
+
+	while ((handle = dmi_memdev_handle(slot_count)) != 0xffff) {
+		slot_count++;
+
+		/* Skip empty slots */
+		mem_size = dmi_memdev_size(handle);
+		if (!mem_size)
+			continue;
+
+		/* Skip undefined memory type */
+		mem_type = dmi_memdev_type(handle);
+		if (mem_type <= 0x02)		/* Invalid, Other, Unknown */
+			continue;
+
+		if (!common_mem_type) {
+			/* First filled slot */
+			common_mem_type = mem_type;
+		} else {
+			/* Check that all filled slots have the same type */
+			if (mem_type != common_mem_type) {
+				dev_warn(&adap->dev,
+					 "Different memory types mixed, not instantiating SPD\n");
+				return;
+			}
+		}
+		dimm_count++;
+	}
+
+	/* No useful DMI data, bail out */
+	if (!dimm_count)
+		return;
+
+	/*
+	 * The max number of SPD EEPROMs that can be addressed per bus is 8.
+	 * If more slots are present either muxed or multiple busses are
+	 * necessary or the additional slots are ignored.
+	 */
+	slot_count = min(slot_count, 8);
+
+	/*
+	 * Memory types could be found at section 7.18.2 (Memory Device — Type), table 78
+	 * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf
+	 */
+	switch (common_mem_type) {
+	case 0x12:	/* DDR */
+	case 0x13:	/* DDR2 */
+	case 0x18:	/* DDR3 */
+	case 0x1B:	/* LPDDR */
+	case 0x1C:	/* LPDDR2 */
+	case 0x1D:	/* LPDDR3 */
+		name = "spd";
+		break;
+	case 0x1A:	/* DDR4 */
+	case 0x1E:	/* LPDDR4 */
+		name = "ee1004";
+		break;
+	case 0x22:	/* DDR5 */
+	case 0x23:	/* LPDDR5 */
+		name = "spd5118";
+		break;
+	default:
+		dev_info(&adap->dev,
+			 "Memory type 0x%02x not supported yet, not instantiating SPD\n",
+			 common_mem_type);
+		return;
+	}
+
+	/*
+	 * We don't know in which slots the memory modules are. We could
+	 * try to guess from the slot names, but that would be rather complex
+	 * and unreliable, so better probe all possible addresses until we
+	 * have found all memory modules.
+	 */
+	for (n = 0; n < slot_count && dimm_count; n++) {
+		struct i2c_board_info info;
+		unsigned short addr_list[2];
+
+		memset(&info, 0, sizeof(struct i2c_board_info));
+		strscpy(info.type, name, I2C_NAME_SIZE);
+		addr_list[0] = 0x50 + n;
+		addr_list[1] = I2C_CLIENT_END;
+
+		if (!IS_ERR(i2c_new_scanned_device(adap, &info, addr_list, NULL))) {
+			dev_info(&adap->dev,
+				 "Successfully instantiated SPD at 0x%hx\n",
+				 addr_list[0]);
+			dimm_count--;
+		}
+	}
+}
+EXPORT_SYMBOL_GPL(i2c_register_spd);
+#endif
+
+MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+MODULE_DESCRIPTION("SMBus protocol extensions support");
+MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-lpc.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2017-2020 UfiSpace Technology Corporation.
  * Jason Tsai <jason.cy.tsai@ufispace.com>
+ * Leo Lin <leo.yt.lin@ufispace.com>
  *
  * Based on ad7414.c
  * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
@@ -27,6 +28,7 @@
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/gpio.h>
+#include <linux/version.h>
 
 #define BSP_LOG_R(fmt, args...)                            \
     _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
@@ -116,6 +118,7 @@ enum lpc_sysfs_attributes
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
     ATT_BSP_GPIO_MAX,
+    ATT_BSP_GPIO_BASE,
     ATT_MAX
 };
 
@@ -146,6 +149,9 @@ char bsp_reg[8] = "0x0";
 u8 enable_log_read = LOG_DISABLE;
 u8 enable_log_write = LOG_DISABLE;
 u8 enable_log_sys = LOG_ENABLE;
+
+int lpc_init(void);
+void lpc_exit(void);
 
 /* reg shift */
 static u8 _shift(u8 mask)
@@ -636,7 +642,28 @@ static ssize_t read_gpio_max(struct device *dev,
 
     if (attr->index == ATT_BSP_GPIO_MAX)
     {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
         return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+#else
+        return sprintf(buf, "%d\n", -1);
+#endif
+    }
+    return -1;
+}
+
+/* get gpio base value */
+static ssize_t read_gpio_base(struct device *dev,
+                    struct device_attribute *da,
+                    char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_BASE) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        return sprintf(buf, "%d\n", -1);
+#else
+        return sprintf(buf, "%d\n", GPIO_DYNAMIC_BASE);
+#endif
     }
     return -1;
 }
@@ -672,6 +699,7 @@ static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT
 static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
 static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
 static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
+static SENSOR_DEVICE_ATTR(bsp_gpio_base, S_IRUGO, read_gpio_base, NULL, ATT_BSP_GPIO_BASE);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -717,6 +745,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
     &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_base.dev_attr.attr,
     NULL,
 };
 
@@ -846,7 +875,11 @@ exit:
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int lpc_drv_remove(struct platform_device *pdev)
+#else
+static void lpc_drv_remove(struct platform_device *pdev)
+#endif
 {
     sysfs_remove_group(&pdev->dev.kobj, &cpu_cpld_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &mb_cpld_attr_grp);
@@ -854,7 +887,9 @@ static int lpc_drv_remove(struct platform_device *pdev)
     sysfs_remove_group(&pdev->dev.kobj, &i2c_alert_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bsp_attr_grp);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver lpc_drv = {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-sys-eeprom.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-sys-eeprom.c
@@ -17,7 +17,7 @@
  */
 
 /* enable dev_dbg print out */
-//#define DEBUG 
+//#define DEBUG
 
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <linux/kernel.h>
@@ -105,7 +105,7 @@ static ssize_t sys_eeprom_read(struct file *filp, struct kobject *kobj,
     struct eeprom_data *data = i2c_get_clientdata(client);
     u8 slice;
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -138,7 +138,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
 
     dev_dbg(&client->dev, "sys_eeprom_write off=%d, count=%d\n", (int)off, (int)count);
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -195,22 +195,36 @@ static int sys_eeprom_detect(struct i2c_client *client, struct i2c_board_info *i
     /* EDID EEPROMs are often 24C00 EEPROMs, which answer to all
        addresses 0x50-0x57, but we only care about 0x51 and 0x55. So decline
        attaching to addresses >= 0x56 on DDC buses */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
     if (!(adapter->class & I2C_CLASS_SPD) && client->addr >= 0x56) {
         return -ENODEV;
     }
+#else
+    if (client->addr >= 0x56) {
+        return -ENODEV;
+    }
+#endif
 
     if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_READ_BYTE)
      && !i2c_check_functionality(adapter, I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
         return -ENODEV;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     strlcpy(info->type, "eeprom", I2C_NAME_SIZE);
+#else
+    strscpy(info->type, "eeprom", I2C_NAME_SIZE);
+#endif
 
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int sys_eeprom_probe(struct i2c_client *client,
             const struct i2c_device_id *id)
+#else
+static int sys_eeprom_probe(struct i2c_client *client)
+#endif
 {
     struct eeprom_data *data;
     int err;
@@ -271,13 +285,19 @@ static struct i2c_driver sys_eeprom_driver = {
     .remove     = sys_eeprom_remove,
     .id_table   = sys_eeprom_id,
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     .class      = I2C_CLASS_DDC | I2C_CLASS_SPD,
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+    .class      = I2C_CLASS_SPD,
+#else
+    .class      = 0,
+#endif
     .detect     = sys_eeprom_detect,
     .address_list   = normal_i2c,
 };
 
 module_i2c_driver(sys_eeprom_driver);
 
-MODULE_AUTHOR("Wade <wade.ce.he@ufispace.com>");
-MODULE_DESCRIPTION("UfiSpace Mother Board EEPROM driver");
+MODULE_AUTHOR("Leo Lin <leo.yt.lin@ufispace.com>");
+MODULE_DESCRIPTION("UfiSpace System EEPROM driver");
 MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/Makefile
@@ -1,5 +1,5 @@
 
-MODULE_NAME  = x86-64-ufispace-s9301-32d-cpld.o x86-64-ufispace-s9301-32d-sys-eeprom.o x86-64-ufispace-s9301-32d-lpc.o pddf_custom_sysstatus_module.o 
+MODULE_NAME  = x86-64-ufispace-s9301-32d-cpld.o x86-64-ufispace-s9301-32d-sys-eeprom.o x86-64-ufispace-s9301-32d-lpc.o pddf_custom_sysstatus_module.o x86-64-ufispace-s9301-32d-i2c-smbus.o
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-cpld.c
@@ -1435,9 +1435,15 @@ static void s9301_cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int s9301_cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int s9301_cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct cpld_data *data = NULL;
     int ret = -EPERM;

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-i2c-smbus.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-i2c-smbus.c
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * i2c-smbus.c - SMBus extensions to the I2C protocol
+ *
+ * Copyright (C) 2008 David Brownell
+ * Copyright (C) 2010-2019 Jean Delvare <jdelvare@suse.de>
+ *
+ * In kernel 6.12.41, the system EEPROM (located on i801 bus, address 0) is misrecognized as an SPD.
+ * Since no standard method is available to resolve this conflict, this patch implements a workaround.
+ * 
+ */
+
+#include <linux/device.h>
+#include <linux/dmi.h>
+#include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/version.h>
+
+static int disable_i2c_register_spd = 1;
+module_param(disable_i2c_register_spd, int, 0);
+
+struct i2c_smbus_alert {
+	struct work_struct	alert;
+	struct i2c_client	*ara;		/* Alert response address */
+};
+
+struct alert_data {
+	unsigned short		addr;
+	enum i2c_alert_protocol	type;
+	unsigned int		data;
+};
+
+/* If this is the alerting device, notify its driver */
+static int smbus_do_alert(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+	int ret;
+
+	if (!client || client->addr != data->addr)
+		return 0;
+	if (client->flags & I2C_CLIENT_TEN)
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler.  Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert) {
+			/* Stop iterating after we find the device */
+			driver->alert(client, data->type, data->data);
+			ret = -EBUSY;
+		} else {
+			dev_warn(&client->dev, "no driver alert()!\n");
+			ret = -EOPNOTSUPP;
+		}
+	} else {
+		dev_dbg(&client->dev, "alert with no driver\n");
+		ret = -ENODEV;
+	}
+	device_unlock(dev);
+
+	return ret;
+}
+
+/* Same as above, but call back all drivers with alert handler */
+
+static int smbus_do_alert_force(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+
+	if (!client || (client->flags & I2C_CLIENT_TEN))
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler. Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert)
+			driver->alert(client, data->type, data->data);
+	}
+	device_unlock(dev);
+
+	return 0;
+}
+
+/*
+ * The alert IRQ handler needs to hand work off to a task which can issue
+ * SMBus calls, because those sleeping calls can't be made in IRQ context.
+ */
+static irqreturn_t smbus_alert(int irq, void *d)
+{
+	struct i2c_smbus_alert *alert = d;
+	struct i2c_client *ara;
+	unsigned short prev_addr = I2C_CLIENT_END; /* Not a valid address */
+
+	ara = alert->ara;
+
+	for (;;) {
+		s32 status;
+		struct alert_data data;
+
+		/*
+		 * Devices with pending alerts reply in address order, low
+		 * to high, because of slave transmit arbitration.  After
+		 * responding, an SMBus device stops asserting SMBALERT#.
+		 *
+		 * Note that SMBus 2.0 reserves 10-bit addresses for future
+		 * use.  We neither handle them, nor try to use PEC here.
+		 */
+		status = i2c_smbus_read_byte(ara);
+		if (status < 0)
+			break;
+
+		data.data = status & 1;
+		data.addr = status >> 1;
+		data.type = I2C_PROTOCOL_SMBUS_ALERT;
+
+		dev_dbg(&ara->dev, "SMBALERT# from dev 0x%02x, flag %d\n",
+			data.addr, data.data);
+
+		/* Notify driver for the device which issued the alert */
+		status = device_for_each_child(&ara->adapter->dev, &data,
+					       smbus_do_alert);
+		/*
+		 * If we read the same address more than once, and the alert
+		 * was not handled by a driver, it won't do any good to repeat
+		 * the loop because it will never terminate. Try again, this
+		 * time calling the alert handlers of all devices connected to
+		 * the bus, and abort the loop afterwards. If this helps, we
+		 * are all set. If it doesn't, there is nothing else we can do,
+		 * so we might as well abort the loop.
+		 * Note: This assumes that a driver with alert handler handles
+		 * the alert properly and clears it if necessary.
+		 */
+		if (data.addr == prev_addr && status != -EBUSY) {
+			device_for_each_child(&ara->adapter->dev, &data,
+					      smbus_do_alert_force);
+			break;
+		}
+		prev_addr = data.addr;
+	}
+
+	return IRQ_HANDLED;
+}
+
+static void smbalert_work(struct work_struct *work)
+{
+	struct i2c_smbus_alert *alert;
+
+	alert = container_of(work, struct i2c_smbus_alert, alert);
+
+	smbus_alert(0, alert);
+
+}
+
+/* Setup SMBALERT# infrastructure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int smbalert_probe(struct i2c_client *ara,
+			const struct i2c_device_id *dev_id)
+{
+#else
+static int smbalert_probe(struct i2c_client *ara)
+{
+#endif
+	struct i2c_smbus_alert_setup *setup = dev_get_platdata(&ara->dev);
+	struct i2c_smbus_alert *alert;
+	struct i2c_adapter *adapter = ara->adapter;
+	int res, irq;
+
+	alert = devm_kzalloc(&ara->dev, sizeof(struct i2c_smbus_alert),
+			     GFP_KERNEL);
+	if (!alert)
+		return -ENOMEM;
+
+	if (setup) {
+		irq = setup->irq;
+	} else {
+		irq = fwnode_irq_get_byname(dev_fwnode(adapter->dev.parent),
+					    "smbus_alert");
+		if (irq <= 0)
+			return irq;
+	}
+
+	INIT_WORK(&alert->alert, smbalert_work);
+	alert->ara = ara;
+
+	if (irq > 0) {
+		res = devm_request_threaded_irq(&ara->dev, irq,
+						NULL, smbus_alert,
+						IRQF_SHARED | IRQF_ONESHOT,
+						"smbus_alert", alert);
+		if (res)
+			return res;
+	}
+
+	i2c_set_clientdata(ara, alert);
+	dev_info(&adapter->dev, "supports SMBALERT#\n");
+
+	return 0;
+}
+
+/* IRQ and memory resources are managed so they are freed automatically */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int
+#else
+static void
+#endif
+smbalert_remove(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	cancel_work_sync(&alert->alert);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id smbalert_ids[] = {
+	{ "smbus_alert" },
+	{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, smbalert_ids);
+
+static struct i2c_driver smbalert_driver = {
+	.driver = {
+		.name	= "smbus_alert",
+	},
+	.probe		= smbalert_probe,
+	.remove		= smbalert_remove,
+	.id_table	= smbalert_ids,
+};
+
+/**
+ * i2c_handle_smbus_alert - Handle an SMBus alert
+ * @ara: the ARA client on the relevant adapter
+ * Context: can't sleep
+ *
+ * Helper function to be called from an I2C bus driver's interrupt
+ * handler. It will schedule the alert work, in turn calling the
+ * corresponding I2C device driver's alert function.
+ *
+ * It is assumed that ara is a valid i2c client previously returned by
+ * i2c_new_smbus_alert_device().
+ */
+int i2c_handle_smbus_alert(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	return schedule_work(&alert->alert);
+}
+EXPORT_SYMBOL_GPL(i2c_handle_smbus_alert);
+
+module_i2c_driver(smbalert_driver);
+
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+#define SMBUS_HOST_NOTIFY_LEN	3
+struct i2c_slave_host_notify_status {
+	u8 index;
+	u8 addr;
+};
+
+static int i2c_slave_host_notify_cb(struct i2c_client *client,
+				    enum i2c_slave_event event, u8 *val)
+{
+	struct i2c_slave_host_notify_status *status = client->dev.platform_data;
+
+	switch (event) {
+	case I2C_SLAVE_WRITE_RECEIVED:
+		/* We only retrieve the first byte received (addr)
+		 * since there is currently no support to retrieve the data
+		 * parameter from the client.
+		 */
+		if (status->index == 0)
+			status->addr = *val;
+		if (status->index < U8_MAX)
+			status->index++;
+		break;
+	case I2C_SLAVE_STOP:
+		if (status->index == SMBUS_HOST_NOTIFY_LEN)
+			i2c_handle_smbus_host_notify(client->adapter,
+						     status->addr);
+		fallthrough;
+	case I2C_SLAVE_WRITE_REQUESTED:
+		status->index = 0;
+		break;
+	case I2C_SLAVE_READ_REQUESTED:
+	case I2C_SLAVE_READ_PROCESSED:
+		*val = 0xff;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * i2c_new_slave_host_notify_device - get a client for SMBus host-notify support
+ * @adapter: the target adapter
+ * Context: can sleep
+ *
+ * Setup handling of the SMBus host-notify protocol on a given I2C bus segment.
+ *
+ * Handling is done by creating a device and its callback and handling data
+ * received via the SMBus host-notify address (0x8)
+ *
+ * This returns the client, which should be ultimately freed using
+ * i2c_free_slave_host_notify_device(); or an ERRPTR to indicate an error.
+ */
+struct i2c_client *i2c_new_slave_host_notify_device(struct i2c_adapter *adapter)
+{
+	struct i2c_board_info host_notify_board_info = {
+		I2C_BOARD_INFO("smbus_host_notify", 0x08),
+		.flags  = I2C_CLIENT_SLAVE,
+	};
+	struct i2c_slave_host_notify_status *status;
+	struct i2c_client *client;
+	int ret;
+
+	status = kzalloc(sizeof(struct i2c_slave_host_notify_status),
+			 GFP_KERNEL);
+	if (!status)
+		return ERR_PTR(-ENOMEM);
+
+	host_notify_board_info.platform_data = status;
+
+	client = i2c_new_client_device(adapter, &host_notify_board_info);
+	if (IS_ERR(client)) {
+		kfree(status);
+		return client;
+	}
+
+	ret = i2c_slave_register(client, i2c_slave_host_notify_cb);
+	if (ret) {
+		i2c_unregister_device(client);
+		kfree(status);
+		return ERR_PTR(ret);
+	}
+
+	return client;
+}
+EXPORT_SYMBOL_GPL(i2c_new_slave_host_notify_device);
+
+/**
+ * i2c_free_slave_host_notify_device - free the client for SMBus host-notify
+ * support
+ * @client: the client to free
+ * Context: can sleep
+ *
+ * Free the i2c_client allocated via i2c_new_slave_host_notify_device
+ */
+void i2c_free_slave_host_notify_device(struct i2c_client *client)
+{
+	if (IS_ERR_OR_NULL(client))
+		return;
+
+	i2c_slave_unregister(client);
+	kfree(client->dev.platform_data);
+	i2c_unregister_device(client);
+}
+EXPORT_SYMBOL_GPL(i2c_free_slave_host_notify_device);
+#endif
+
+/*
+ * SPD is not part of SMBus but we include it here for convenience as the
+ * target systems are the same.
+ * Restrictions to automatic SPD instantiation:
+ *  - Only works if all filled slots have the same memory type
+ *  - Only works for (LP)DDR memory types up to DDR5
+ *  - Only works on systems with 1 to 8 memory slots
+ */
+#if IS_ENABLED(CONFIG_DMI)
+void i2c_register_spd(struct i2c_adapter *adap)
+{
+	int n, slot_count = 0, dimm_count = 0;
+	u16 handle;
+	u8 common_mem_type = 0x0, mem_type;
+	u64 mem_size;
+	const char *name;
+
+	//disable spd scan to prevent address conflict between spd and sys eeprom
+	if (disable_i2c_register_spd == 1) {
+		return;
+	}
+
+	while ((handle = dmi_memdev_handle(slot_count)) != 0xffff) {
+		slot_count++;
+
+		/* Skip empty slots */
+		mem_size = dmi_memdev_size(handle);
+		if (!mem_size)
+			continue;
+
+		/* Skip undefined memory type */
+		mem_type = dmi_memdev_type(handle);
+		if (mem_type <= 0x02)		/* Invalid, Other, Unknown */
+			continue;
+
+		if (!common_mem_type) {
+			/* First filled slot */
+			common_mem_type = mem_type;
+		} else {
+			/* Check that all filled slots have the same type */
+			if (mem_type != common_mem_type) {
+				dev_warn(&adap->dev,
+					 "Different memory types mixed, not instantiating SPD\n");
+				return;
+			}
+		}
+		dimm_count++;
+	}
+
+	/* No useful DMI data, bail out */
+	if (!dimm_count)
+		return;
+
+	/*
+	 * The max number of SPD EEPROMs that can be addressed per bus is 8.
+	 * If more slots are present either muxed or multiple busses are
+	 * necessary or the additional slots are ignored.
+	 */
+	slot_count = min(slot_count, 8);
+
+	/*
+	 * Memory types could be found at section 7.18.2 (Memory Device — Type), table 78
+	 * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf
+	 */
+	switch (common_mem_type) {
+	case 0x12:	/* DDR */
+	case 0x13:	/* DDR2 */
+	case 0x18:	/* DDR3 */
+	case 0x1B:	/* LPDDR */
+	case 0x1C:	/* LPDDR2 */
+	case 0x1D:	/* LPDDR3 */
+		name = "spd";
+		break;
+	case 0x1A:	/* DDR4 */
+	case 0x1E:	/* LPDDR4 */
+		name = "ee1004";
+		break;
+	case 0x22:	/* DDR5 */
+	case 0x23:	/* LPDDR5 */
+		name = "spd5118";
+		break;
+	default:
+		dev_info(&adap->dev,
+			 "Memory type 0x%02x not supported yet, not instantiating SPD\n",
+			 common_mem_type);
+		return;
+	}
+
+	/*
+	 * We don't know in which slots the memory modules are. We could
+	 * try to guess from the slot names, but that would be rather complex
+	 * and unreliable, so better probe all possible addresses until we
+	 * have found all memory modules.
+	 */
+	for (n = 0; n < slot_count && dimm_count; n++) {
+		struct i2c_board_info info;
+		unsigned short addr_list[2];
+
+		memset(&info, 0, sizeof(struct i2c_board_info));
+		strscpy(info.type, name, I2C_NAME_SIZE);
+		addr_list[0] = 0x50 + n;
+		addr_list[1] = I2C_CLIENT_END;
+
+		if (!IS_ERR(i2c_new_scanned_device(adap, &info, addr_list, NULL))) {
+			dev_info(&adap->dev,
+				 "Successfully instantiated SPD at 0x%hx\n",
+				 addr_list[0]);
+			dimm_count--;
+		}
+	}
+}
+EXPORT_SYMBOL_GPL(i2c_register_spd);
+#endif
+
+MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+MODULE_DESCRIPTION("SMBus protocol extensions support");
+MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-lpc.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2017-2020 UfiSpace Technology Corporation.
  * Jason Tsai <jason.cy.tsai@ufispace.com>
+ * Leo Lin <leo.yt.lin@ufispace.com>
  *
  * Based on ad7414.c
  * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
@@ -27,6 +28,7 @@
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/gpio.h>
+#include <linux/version.h>
 
 #define BSP_LOG_R(fmt, args...)                            \
     _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
@@ -116,6 +118,7 @@ enum lpc_sysfs_attributes
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
     ATT_BSP_GPIO_MAX,
+    ATT_BSP_GPIO_BASE,
     ATT_MAX
 };
 
@@ -146,6 +149,9 @@ char bsp_reg[8] = "0x0";
 u8 enable_log_read = LOG_DISABLE;
 u8 enable_log_write = LOG_DISABLE;
 u8 enable_log_sys = LOG_ENABLE;
+
+int lpc_init(void);
+void lpc_exit(void);
 
 /* reg shift */
 static u8 _shift(u8 mask)
@@ -636,7 +642,28 @@ static ssize_t read_gpio_max(struct device *dev,
 
     if (attr->index == ATT_BSP_GPIO_MAX)
     {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
         return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+#else
+        return sprintf(buf, "%d\n", -1);
+#endif
+    }
+    return -1;
+}
+
+/* get gpio base value */
+static ssize_t read_gpio_base(struct device *dev,
+                    struct device_attribute *da,
+                    char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_BASE) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        return sprintf(buf, "%d\n", -1);
+#else
+        return sprintf(buf, "%d\n", GPIO_DYNAMIC_BASE);
+#endif
     }
     return -1;
 }
@@ -672,6 +699,7 @@ static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT
 static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
 static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
 static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
+static SENSOR_DEVICE_ATTR(bsp_gpio_base, S_IRUGO, read_gpio_base, NULL, ATT_BSP_GPIO_BASE);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -717,6 +745,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
     &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_base.dev_attr.attr,
     NULL,
 };
 
@@ -846,7 +875,11 @@ exit:
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int lpc_drv_remove(struct platform_device *pdev)
+#else
+static void lpc_drv_remove(struct platform_device *pdev)
+#endif
 {
     sysfs_remove_group(&pdev->dev.kobj, &cpu_cpld_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &mb_cpld_attr_grp);
@@ -854,7 +887,9 @@ static int lpc_drv_remove(struct platform_device *pdev)
     sysfs_remove_group(&pdev->dev.kobj, &i2c_alert_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bsp_attr_grp);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver lpc_drv = {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-sys-eeprom.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-sys-eeprom.c
@@ -17,7 +17,7 @@
  */
 
 /* enable dev_dbg print out */
-//#define DEBUG 
+//#define DEBUG
 
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <linux/kernel.h>
@@ -89,7 +89,7 @@ static void sys_eeprom_update_client(struct i2c_client *client, u8 slice)
                 data->data[j] = res & 0xFF;
             }
         }
-        
+
         data->last_updated[slice] = jiffies;
         data->valid |= (1 << slice);
     }
@@ -105,7 +105,7 @@ static ssize_t sys_eeprom_read(struct file *filp, struct kobject *kobj,
     struct eeprom_data *data = i2c_get_clientdata(client);
     u8 slice;
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -138,7 +138,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
 
     dev_dbg(&client->dev, "sys_eeprom_write off=%d, count=%d\n", (int)off, (int)count);
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -163,7 +163,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
         }
 
         off++;
-        
+
         /* need to wait for write complete */
         udelay(10000);
     }
@@ -195,22 +195,36 @@ static int sys_eeprom_detect(struct i2c_client *client, struct i2c_board_info *i
     /* EDID EEPROMs are often 24C00 EEPROMs, which answer to all
        addresses 0x50-0x57, but we only care about 0x51 and 0x55. So decline
        attaching to addresses >= 0x56 on DDC buses */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
     if (!(adapter->class & I2C_CLASS_SPD) && client->addr >= 0x56) {
         return -ENODEV;
     }
+#else
+    if (client->addr >= 0x56) {
+        return -ENODEV;
+    }
+#endif
 
     if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_READ_BYTE)
      && !i2c_check_functionality(adapter, I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
         return -ENODEV;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     strlcpy(info->type, "eeprom", I2C_NAME_SIZE);
+#else
+    strscpy(info->type, "eeprom", I2C_NAME_SIZE);
+#endif
 
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int sys_eeprom_probe(struct i2c_client *client,
             const struct i2c_device_id *id)
+#else
+static int sys_eeprom_probe(struct i2c_client *client)
+#endif
 {
     struct eeprom_data *data;
     int err;
@@ -271,13 +285,19 @@ static struct i2c_driver sys_eeprom_driver = {
     .remove     = sys_eeprom_remove,
     .id_table   = sys_eeprom_id,
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     .class      = I2C_CLASS_DDC | I2C_CLASS_SPD,
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+    .class      = I2C_CLASS_SPD,
+#else
+    .class      = 0,
+#endif
     .detect     = sys_eeprom_detect,
     .address_list   = normal_i2c,
 };
 
 module_i2c_driver(sys_eeprom_driver);
 
-MODULE_AUTHOR("Wade <wade.ce.he@ufispace.com>");
-MODULE_DESCRIPTION("UfiSpace Mother Board EEPROM driver");
+MODULE_AUTHOR("Leo Lin <leo.yt.lin@ufispace.com>");
+MODULE_DESCRIPTION("UfiSpace System EEPROM driver");
 MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/Makefile
@@ -1,5 +1,5 @@
 
-MODULE_NAME  = x86-64-ufispace-s9301-32db-cpld.o x86-64-ufispace-s9301-32db-sys-eeprom.o x86-64-ufispace-s9301-32db-lpc.o pddf_custom_sysstatus_module.o 
+MODULE_NAME  = x86-64-ufispace-s9301-32db-cpld.o x86-64-ufispace-s9301-32db-sys-eeprom.o x86-64-ufispace-s9301-32db-lpc.o pddf_custom_sysstatus_module.o x86-64-ufispace-s9301-32db-i2c-smbus.o
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-cpld.c
@@ -630,7 +630,7 @@ static const struct attribute_group s9301_cpld3_group = {
 
 static int _bsp_log(u8 log_type, char *fmt, ...)
 {
-    if((log_type==LOG_READ  && enable_log_read) ||
+    if ((log_type==LOG_READ  && enable_log_read) ||
         (log_type==LOG_WRITE && enable_log_write)) {
         va_list args;
         int r;
@@ -698,7 +698,7 @@ static ssize_t read_bsp_callback(struct device *dev,
     int str_len=0;
     char *str=NULL;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case BSP_DEBUG:
             str = bsp_debug;
             str_len = sizeof(bsp_debug);
@@ -719,15 +719,15 @@ static ssize_t write_bsp_callback(struct device *dev,
     ssize_t ret = 0;
     u8 bsp_debug_u8 = 0;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case BSP_DEBUG:
             str = bsp_debug;
             str_len = sizeof(bsp_debug);
             ret = write_bsp(buf, str, str_len, count);
 
-            if(kstrtou8(buf, 0, &bsp_debug_u8) < 0) {
+            if (kstrtou8(buf, 0, &bsp_debug_u8) < 0) {
                 return -EINVAL;
-            } else if(_config_bsp_log(bsp_debug_u8) < 0) {
+            } else if (_config_bsp_log(bsp_debug_u8) < 0) {
                 return -EINVAL;
             }
             return ret;
@@ -759,7 +759,7 @@ static ssize_t write_access_register(struct device *dev,
     struct cpld_data *data = i2c_get_clientdata(client);
     u8 reg;
 
-    if(kstrtou8(buf, 0, &reg) < 0)
+    if (kstrtou8(buf, 0, &reg) < 0)
         return -EINVAL;
 
     data->access_reg = reg;
@@ -778,7 +778,7 @@ static ssize_t read_register_value(struct device *dev,
 
     I2C_READ_BYTE_DATA(reg_val, &data->access_lock, client, reg);
 
-    if(reg_val < 0)
+    if (reg_val < 0)
         return reg_val;
 
     return sprintf(buf, "0x%x\n", reg_val);
@@ -796,12 +796,12 @@ static ssize_t write_register_value(struct device *dev,
     u8 reg = data->access_reg;
     u8 reg_val;
 
-    if(kstrtou8(buf, 0, &reg_val) < 0)
+    if (kstrtou8(buf, 0, &reg_val) < 0)
         return -EINVAL;
 
     I2C_WRITE_BYTE_DATA(ret, &data->access_lock, client, reg, reg_val);
 
-    if(unlikely(ret < 0)) {
+    if (unlikely(ret < 0)) {
         dev_err(dev, "I2C_WRITE_BYTE_DATA error, return=%d\n", ret);
         return ret;
     }
@@ -816,7 +816,7 @@ static ssize_t read_cpld_reg(struct device *dev,
 {
     int reg_val;
 
-    if(read_cpld_reg_raw_int(dev, reg, &reg_val))
+    if (read_cpld_reg_raw_int(dev, reg, &reg_val))
         return sprintf(buf, "0x%02x\n", reg_val);
     else
         return reg_val;
@@ -827,7 +827,7 @@ static bool read_cpld_reg_raw_int(struct device *dev, u8 reg, int *val)
     struct i2c_client *client = to_i2c_client(dev);
     struct cpld_data *data = i2c_get_clientdata(client);
     I2C_READ_BYTE_DATA(*val, &data->access_lock, client, reg);
-    if(unlikely(*val < 0)) {
+    if (unlikely(*val < 0)) {
         dev_err(dev, "read_cpld_reg_raw_int() error, return=%d\n", *val);
         return false;
     }
@@ -838,7 +838,7 @@ static bool read_cpld_reg_raw_byte(struct device *dev, u8 reg, u8 *val, int *err
 {
     int reg_val;
 
-    if(read_cpld_reg_raw_int(dev, reg, &reg_val)) {
+    if (read_cpld_reg_raw_int(dev, reg, &reg_val)) {
         *val = (u8)reg_val;
         return true;
     } else {
@@ -854,7 +854,7 @@ static ssize_t read_cpld_callback(struct device *dev,
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u8 reg = 0;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case CPLD_SKU_ID:
              reg = CPLD_SKU_ID_REG;
              break;
@@ -1156,10 +1156,10 @@ static ssize_t read_hw_rev_cb(struct device *dev,
     int errno = 0;
     u8 res;
 
-    if(!read_cpld_reg_raw_byte(dev, reg, &reg_val, &errno))
+    if (!read_cpld_reg_raw_byte(dev, reg, &reg_val, &errno))
         return errno;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case CPLD_HW_REV:
              HW_REV_GET(reg_val, res);
              break;
@@ -1188,10 +1188,10 @@ static ssize_t read_cpld_version_cb(struct device *dev,
     int errno = 0;
     u8 res;
 
-    if(!read_cpld_reg_raw_byte(dev, reg, &reg_val, &errno))
+    if (!read_cpld_reg_raw_byte(dev, reg, &reg_val, &errno))
         return errno;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case CPLD_MAJOR_VER:
              CPLD_MAJOR_VERSION_GET(reg_val, res);
              break;
@@ -1235,7 +1235,7 @@ static ssize_t write_cpld_callback(struct device *dev,
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u8 reg = 0;
 
-    switch(attr->index) {
+    switch (attr->index) {
         case CPLD_MAC_INTR_MASK:
              reg = CPLD_MAC_INTR_MASK_REG;
              break;
@@ -1385,13 +1385,13 @@ static ssize_t write_cpld_reg(struct device *dev,
     u8 reg_val;
     int ret;
 
-    if(kstrtou8(buf, 0, &reg_val) < 0)
+    if (kstrtou8(buf, 0, &reg_val) < 0)
         return -EINVAL;
 
     I2C_WRITE_BYTE_DATA(ret, &data->access_lock,
                client, reg, reg_val);
 
-    if(unlikely(ret < 0)) {
+    if (unlikely(ret < 0)) {
         dev_err(dev, "I2C_WRITE_BYTE_DATA error, return=%d\n", ret);
         return ret;
     }
@@ -1405,7 +1405,7 @@ static void s9301_cpld_add_client(struct i2c_client *client)
     struct cpld_client_node *node = NULL;
 
     node = kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
-    if(!node) {
+    if (!node) {
         dev_info(&client->dev,
             "Can't allocate cpld_client_node for index %d\n",
             client->addr);
@@ -1431,13 +1431,13 @@ static void s9301_cpld_remove_client(struct i2c_client *client)
         cpld_node = list_entry(list_node,
                 struct cpld_client_node, list);
 
-        if(cpld_node->client == client) {
+        if (cpld_node->client == client) {
             found = 1;
             break;
         }
     }
 
-    if(found) {
+    if (found) {
         list_del(list_node);
         kfree(cpld_node);
     }
@@ -1445,23 +1445,29 @@ static void s9301_cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int s9301_cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int s9301_cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct cpld_data *data = NULL;
     int ret = -EPERM;
     int idx;
 
     data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
-    if(!data)
+    if (!data)
         return -ENOMEM;
 
     /* init cpld data for client */
     i2c_set_clientdata(client, data);
     mutex_init(&data->access_lock);
 
-    if(!i2c_check_functionality(client->adapter,
+    if (!i2c_check_functionality(client->adapter,
                 I2C_FUNC_SMBUS_BYTE_DATA)) {
         dev_info(&client->dev,
             "i2c_check_functionality failed (0x%x)\n",
@@ -1473,7 +1479,7 @@ static int s9301_cpld_probe(struct i2c_client *client,
     /* get cpld id from device */
     ret = i2c_smbus_read_byte_data(client, CPLD_ID_REG);
 
-    if(ret < 0) {
+    if (ret < 0) {
         dev_info(&client->dev,
             "fail to get cpld id (0x%x) at addr (0x%x)\n",
             CPLD_ID_REG, client->addr);
@@ -1483,7 +1489,7 @@ static int s9301_cpld_probe(struct i2c_client *client,
 
     CPLD_ID_ID_GET(ret,  idx);
 
-    if(INVALID(idx, cpld1, cpld3)) {
+    if (INVALID(idx, cpld1, cpld3)) {
         dev_info(&client->dev,
             "cpld id %d(device) not valid\n", idx);
         //status = -EPERM;
@@ -1494,7 +1500,7 @@ static int s9301_cpld_probe(struct i2c_client *client,
 
     /* register sysfs hooks for different cpld group */
     dev_info(&client->dev, "probe cpld with index %d\n", data->index);
-    switch(data->index) {
+    switch (data->index) {
     case cpld1:
         status = sysfs_create_group(&client->dev.kobj,
                     &s9301_cpld1_group);
@@ -1521,7 +1527,7 @@ static int s9301_cpld_probe(struct i2c_client *client,
 
     return 0;
 exit:
-    switch(data->index) {
+    switch (data->index) {
     case cpld1:
         sysfs_remove_group(&client->dev.kobj, &s9301_cpld1_group);
         break;
@@ -1547,7 +1553,7 @@ s9301_cpld_remove(struct i2c_client *client)
 {
     struct cpld_data *data = i2c_get_clientdata(client);
 
-    switch(data->index) {
+    switch (data->index) {
     case cpld1:
         sysfs_remove_group(&client->dev.kobj, &s9301_cpld1_group);
         break;
@@ -1592,7 +1598,7 @@ int s9301_cpld_read(u8 cpld_idx,
         cpld_node = list_entry(list_node,
                     struct cpld_client_node, list);
         data = i2c_get_clientdata(cpld_node->client);
-        if(data->index == cpld_idx) {
+        if (data->index == cpld_idx) {
             DEBUG_PRINT("cpld_idx=%d, read reg 0x%02x",
                     cpld_idx, reg);
             I2C_READ_BYTE_DATA(ret, &data->access_lock,
@@ -1623,7 +1629,7 @@ int s9301_cpld_write(u8 cpld_idx,
                     struct cpld_client_node, list);
         data = i2c_get_clientdata(cpld_node->client);
 
-        if(data->index == cpld_idx) {
+        if (data->index == cpld_idx) {
                         I2C_WRITE_BYTE_DATA(ret, &data->access_lock,
                         cpld_node->client,
                         reg, value);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-i2c-smbus.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-i2c-smbus.c
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * i2c-smbus.c - SMBus extensions to the I2C protocol
+ *
+ * Copyright (C) 2008 David Brownell
+ * Copyright (C) 2010-2019 Jean Delvare <jdelvare@suse.de>
+ *
+ * In kernel 6.12.41, the system EEPROM (located on i801 bus, address 0) is misrecognized as an SPD.
+ * Since no standard method is available to resolve this conflict, this patch implements a workaround.
+ * 
+ */
+
+#include <linux/device.h>
+#include <linux/dmi.h>
+#include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/version.h>
+
+static int disable_i2c_register_spd = 1;
+module_param(disable_i2c_register_spd, int, 0);
+
+struct i2c_smbus_alert {
+	struct work_struct	alert;
+	struct i2c_client	*ara;		/* Alert response address */
+};
+
+struct alert_data {
+	unsigned short		addr;
+	enum i2c_alert_protocol	type;
+	unsigned int		data;
+};
+
+/* If this is the alerting device, notify its driver */
+static int smbus_do_alert(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+	int ret;
+
+	if (!client || client->addr != data->addr)
+		return 0;
+	if (client->flags & I2C_CLIENT_TEN)
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler.  Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert) {
+			/* Stop iterating after we find the device */
+			driver->alert(client, data->type, data->data);
+			ret = -EBUSY;
+		} else {
+			dev_warn(&client->dev, "no driver alert()!\n");
+			ret = -EOPNOTSUPP;
+		}
+	} else {
+		dev_dbg(&client->dev, "alert with no driver\n");
+		ret = -ENODEV;
+	}
+	device_unlock(dev);
+
+	return ret;
+}
+
+/* Same as above, but call back all drivers with alert handler */
+
+static int smbus_do_alert_force(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+
+	if (!client || (client->flags & I2C_CLIENT_TEN))
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler. Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert)
+			driver->alert(client, data->type, data->data);
+	}
+	device_unlock(dev);
+
+	return 0;
+}
+
+/*
+ * The alert IRQ handler needs to hand work off to a task which can issue
+ * SMBus calls, because those sleeping calls can't be made in IRQ context.
+ */
+static irqreturn_t smbus_alert(int irq, void *d)
+{
+	struct i2c_smbus_alert *alert = d;
+	struct i2c_client *ara;
+	unsigned short prev_addr = I2C_CLIENT_END; /* Not a valid address */
+
+	ara = alert->ara;
+
+	for (;;) {
+		s32 status;
+		struct alert_data data;
+
+		/*
+		 * Devices with pending alerts reply in address order, low
+		 * to high, because of slave transmit arbitration.  After
+		 * responding, an SMBus device stops asserting SMBALERT#.
+		 *
+		 * Note that SMBus 2.0 reserves 10-bit addresses for future
+		 * use.  We neither handle them, nor try to use PEC here.
+		 */
+		status = i2c_smbus_read_byte(ara);
+		if (status < 0)
+			break;
+
+		data.data = status & 1;
+		data.addr = status >> 1;
+		data.type = I2C_PROTOCOL_SMBUS_ALERT;
+
+		dev_dbg(&ara->dev, "SMBALERT# from dev 0x%02x, flag %d\n",
+			data.addr, data.data);
+
+		/* Notify driver for the device which issued the alert */
+		status = device_for_each_child(&ara->adapter->dev, &data,
+					       smbus_do_alert);
+		/*
+		 * If we read the same address more than once, and the alert
+		 * was not handled by a driver, it won't do any good to repeat
+		 * the loop because it will never terminate. Try again, this
+		 * time calling the alert handlers of all devices connected to
+		 * the bus, and abort the loop afterwards. If this helps, we
+		 * are all set. If it doesn't, there is nothing else we can do,
+		 * so we might as well abort the loop.
+		 * Note: This assumes that a driver with alert handler handles
+		 * the alert properly and clears it if necessary.
+		 */
+		if (data.addr == prev_addr && status != -EBUSY) {
+			device_for_each_child(&ara->adapter->dev, &data,
+					      smbus_do_alert_force);
+			break;
+		}
+		prev_addr = data.addr;
+	}
+
+	return IRQ_HANDLED;
+}
+
+static void smbalert_work(struct work_struct *work)
+{
+	struct i2c_smbus_alert *alert;
+
+	alert = container_of(work, struct i2c_smbus_alert, alert);
+
+	smbus_alert(0, alert);
+
+}
+
+/* Setup SMBALERT# infrastructure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int smbalert_probe(struct i2c_client *ara,
+			const struct i2c_device_id *dev_id)
+{
+#else
+static int smbalert_probe(struct i2c_client *ara)
+{
+#endif
+	struct i2c_smbus_alert_setup *setup = dev_get_platdata(&ara->dev);
+	struct i2c_smbus_alert *alert;
+	struct i2c_adapter *adapter = ara->adapter;
+	int res, irq;
+
+	alert = devm_kzalloc(&ara->dev, sizeof(struct i2c_smbus_alert),
+			     GFP_KERNEL);
+	if (!alert)
+		return -ENOMEM;
+
+	if (setup) {
+		irq = setup->irq;
+	} else {
+		irq = fwnode_irq_get_byname(dev_fwnode(adapter->dev.parent),
+					    "smbus_alert");
+		if (irq <= 0)
+			return irq;
+	}
+
+	INIT_WORK(&alert->alert, smbalert_work);
+	alert->ara = ara;
+
+	if (irq > 0) {
+		res = devm_request_threaded_irq(&ara->dev, irq,
+						NULL, smbus_alert,
+						IRQF_SHARED | IRQF_ONESHOT,
+						"smbus_alert", alert);
+		if (res)
+			return res;
+	}
+
+	i2c_set_clientdata(ara, alert);
+	dev_info(&adapter->dev, "supports SMBALERT#\n");
+
+	return 0;
+}
+
+/* IRQ and memory resources are managed so they are freed automatically */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int
+#else
+static void
+#endif
+smbalert_remove(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	cancel_work_sync(&alert->alert);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id smbalert_ids[] = {
+	{ "smbus_alert" },
+	{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, smbalert_ids);
+
+static struct i2c_driver smbalert_driver = {
+	.driver = {
+		.name	= "smbus_alert",
+	},
+	.probe		= smbalert_probe,
+	.remove		= smbalert_remove,
+	.id_table	= smbalert_ids,
+};
+
+/**
+ * i2c_handle_smbus_alert - Handle an SMBus alert
+ * @ara: the ARA client on the relevant adapter
+ * Context: can't sleep
+ *
+ * Helper function to be called from an I2C bus driver's interrupt
+ * handler. It will schedule the alert work, in turn calling the
+ * corresponding I2C device driver's alert function.
+ *
+ * It is assumed that ara is a valid i2c client previously returned by
+ * i2c_new_smbus_alert_device().
+ */
+int i2c_handle_smbus_alert(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	return schedule_work(&alert->alert);
+}
+EXPORT_SYMBOL_GPL(i2c_handle_smbus_alert);
+
+module_i2c_driver(smbalert_driver);
+
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+#define SMBUS_HOST_NOTIFY_LEN	3
+struct i2c_slave_host_notify_status {
+	u8 index;
+	u8 addr;
+};
+
+static int i2c_slave_host_notify_cb(struct i2c_client *client,
+				    enum i2c_slave_event event, u8 *val)
+{
+	struct i2c_slave_host_notify_status *status = client->dev.platform_data;
+
+	switch (event) {
+	case I2C_SLAVE_WRITE_RECEIVED:
+		/* We only retrieve the first byte received (addr)
+		 * since there is currently no support to retrieve the data
+		 * parameter from the client.
+		 */
+		if (status->index == 0)
+			status->addr = *val;
+		if (status->index < U8_MAX)
+			status->index++;
+		break;
+	case I2C_SLAVE_STOP:
+		if (status->index == SMBUS_HOST_NOTIFY_LEN)
+			i2c_handle_smbus_host_notify(client->adapter,
+						     status->addr);
+		fallthrough;
+	case I2C_SLAVE_WRITE_REQUESTED:
+		status->index = 0;
+		break;
+	case I2C_SLAVE_READ_REQUESTED:
+	case I2C_SLAVE_READ_PROCESSED:
+		*val = 0xff;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * i2c_new_slave_host_notify_device - get a client for SMBus host-notify support
+ * @adapter: the target adapter
+ * Context: can sleep
+ *
+ * Setup handling of the SMBus host-notify protocol on a given I2C bus segment.
+ *
+ * Handling is done by creating a device and its callback and handling data
+ * received via the SMBus host-notify address (0x8)
+ *
+ * This returns the client, which should be ultimately freed using
+ * i2c_free_slave_host_notify_device(); or an ERRPTR to indicate an error.
+ */
+struct i2c_client *i2c_new_slave_host_notify_device(struct i2c_adapter *adapter)
+{
+	struct i2c_board_info host_notify_board_info = {
+		I2C_BOARD_INFO("smbus_host_notify", 0x08),
+		.flags  = I2C_CLIENT_SLAVE,
+	};
+	struct i2c_slave_host_notify_status *status;
+	struct i2c_client *client;
+	int ret;
+
+	status = kzalloc(sizeof(struct i2c_slave_host_notify_status),
+			 GFP_KERNEL);
+	if (!status)
+		return ERR_PTR(-ENOMEM);
+
+	host_notify_board_info.platform_data = status;
+
+	client = i2c_new_client_device(adapter, &host_notify_board_info);
+	if (IS_ERR(client)) {
+		kfree(status);
+		return client;
+	}
+
+	ret = i2c_slave_register(client, i2c_slave_host_notify_cb);
+	if (ret) {
+		i2c_unregister_device(client);
+		kfree(status);
+		return ERR_PTR(ret);
+	}
+
+	return client;
+}
+EXPORT_SYMBOL_GPL(i2c_new_slave_host_notify_device);
+
+/**
+ * i2c_free_slave_host_notify_device - free the client for SMBus host-notify
+ * support
+ * @client: the client to free
+ * Context: can sleep
+ *
+ * Free the i2c_client allocated via i2c_new_slave_host_notify_device
+ */
+void i2c_free_slave_host_notify_device(struct i2c_client *client)
+{
+	if (IS_ERR_OR_NULL(client))
+		return;
+
+	i2c_slave_unregister(client);
+	kfree(client->dev.platform_data);
+	i2c_unregister_device(client);
+}
+EXPORT_SYMBOL_GPL(i2c_free_slave_host_notify_device);
+#endif
+
+/*
+ * SPD is not part of SMBus but we include it here for convenience as the
+ * target systems are the same.
+ * Restrictions to automatic SPD instantiation:
+ *  - Only works if all filled slots have the same memory type
+ *  - Only works for (LP)DDR memory types up to DDR5
+ *  - Only works on systems with 1 to 8 memory slots
+ */
+#if IS_ENABLED(CONFIG_DMI)
+void i2c_register_spd(struct i2c_adapter *adap)
+{
+	int n, slot_count = 0, dimm_count = 0;
+	u16 handle;
+	u8 common_mem_type = 0x0, mem_type;
+	u64 mem_size;
+	const char *name;
+
+	//disable spd scan to prevent address conflict between spd and sys eeprom
+	if (disable_i2c_register_spd == 1) {
+		return;
+	}
+
+	while ((handle = dmi_memdev_handle(slot_count)) != 0xffff) {
+		slot_count++;
+
+		/* Skip empty slots */
+		mem_size = dmi_memdev_size(handle);
+		if (!mem_size)
+			continue;
+
+		/* Skip undefined memory type */
+		mem_type = dmi_memdev_type(handle);
+		if (mem_type <= 0x02)		/* Invalid, Other, Unknown */
+			continue;
+
+		if (!common_mem_type) {
+			/* First filled slot */
+			common_mem_type = mem_type;
+		} else {
+			/* Check that all filled slots have the same type */
+			if (mem_type != common_mem_type) {
+				dev_warn(&adap->dev,
+					 "Different memory types mixed, not instantiating SPD\n");
+				return;
+			}
+		}
+		dimm_count++;
+	}
+
+	/* No useful DMI data, bail out */
+	if (!dimm_count)
+		return;
+
+	/*
+	 * The max number of SPD EEPROMs that can be addressed per bus is 8.
+	 * If more slots are present either muxed or multiple busses are
+	 * necessary or the additional slots are ignored.
+	 */
+	slot_count = min(slot_count, 8);
+
+	/*
+	 * Memory types could be found at section 7.18.2 (Memory Device — Type), table 78
+	 * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf
+	 */
+	switch (common_mem_type) {
+	case 0x12:	/* DDR */
+	case 0x13:	/* DDR2 */
+	case 0x18:	/* DDR3 */
+	case 0x1B:	/* LPDDR */
+	case 0x1C:	/* LPDDR2 */
+	case 0x1D:	/* LPDDR3 */
+		name = "spd";
+		break;
+	case 0x1A:	/* DDR4 */
+	case 0x1E:	/* LPDDR4 */
+		name = "ee1004";
+		break;
+	case 0x22:	/* DDR5 */
+	case 0x23:	/* LPDDR5 */
+		name = "spd5118";
+		break;
+	default:
+		dev_info(&adap->dev,
+			 "Memory type 0x%02x not supported yet, not instantiating SPD\n",
+			 common_mem_type);
+		return;
+	}
+
+	/*
+	 * We don't know in which slots the memory modules are. We could
+	 * try to guess from the slot names, but that would be rather complex
+	 * and unreliable, so better probe all possible addresses until we
+	 * have found all memory modules.
+	 */
+	for (n = 0; n < slot_count && dimm_count; n++) {
+		struct i2c_board_info info;
+		unsigned short addr_list[2];
+
+		memset(&info, 0, sizeof(struct i2c_board_info));
+		strscpy(info.type, name, I2C_NAME_SIZE);
+		addr_list[0] = 0x50 + n;
+		addr_list[1] = I2C_CLIENT_END;
+
+		if (!IS_ERR(i2c_new_scanned_device(adap, &info, addr_list, NULL))) {
+			dev_info(&adap->dev,
+				 "Successfully instantiated SPD at 0x%hx\n",
+				 addr_list[0]);
+			dimm_count--;
+		}
+	}
+}
+EXPORT_SYMBOL_GPL(i2c_register_spd);
+#endif
+
+MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+MODULE_DESCRIPTION("SMBus protocol extensions support");
+MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-lpc.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2017-2020 UfiSpace Technology Corporation.
  * Jason Tsai <jason.cy.tsai@ufispace.com>
+ * Leo Lin <leo.yt.lin@ufispace.com>
  *
  * Based on ad7414.c
  * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
@@ -27,6 +28,7 @@
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/gpio.h>
+#include <linux/version.h>
 
 #define BSP_LOG_R(fmt, args...)                            \
     _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
@@ -116,6 +118,7 @@ enum lpc_sysfs_attributes
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
     ATT_BSP_GPIO_MAX,
+    ATT_BSP_GPIO_BASE,
     ATT_MAX
 };
 
@@ -146,6 +149,9 @@ char bsp_reg[8] = "0x0";
 u8 enable_log_read = LOG_DISABLE;
 u8 enable_log_write = LOG_DISABLE;
 u8 enable_log_sys = LOG_ENABLE;
+
+int lpc_init(void);
+void lpc_exit(void);
 
 /* reg shift */
 static u8 _shift(u8 mask)
@@ -636,7 +642,28 @@ static ssize_t read_gpio_max(struct device *dev,
 
     if (attr->index == ATT_BSP_GPIO_MAX)
     {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
         return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+#else
+        return sprintf(buf, "%d\n", -1);
+#endif
+    }
+    return -1;
+}
+
+/* get gpio base value */
+static ssize_t read_gpio_base(struct device *dev,
+                    struct device_attribute *da,
+                    char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_BASE) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        return sprintf(buf, "%d\n", -1);
+#else
+        return sprintf(buf, "%d\n", GPIO_DYNAMIC_BASE);
+#endif
     }
     return -1;
 }
@@ -672,6 +699,7 @@ static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT
 static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
 static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
 static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
+static SENSOR_DEVICE_ATTR(bsp_gpio_base, S_IRUGO, read_gpio_base, NULL, ATT_BSP_GPIO_BASE);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -717,6 +745,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
     &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_base.dev_attr.attr,
     NULL,
 };
 
@@ -846,7 +875,11 @@ exit:
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int lpc_drv_remove(struct platform_device *pdev)
+#else
+static void lpc_drv_remove(struct platform_device *pdev)
+#endif
 {
     sysfs_remove_group(&pdev->dev.kobj, &cpu_cpld_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &mb_cpld_attr_grp);
@@ -854,7 +887,9 @@ static int lpc_drv_remove(struct platform_device *pdev)
     sysfs_remove_group(&pdev->dev.kobj, &i2c_alert_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bsp_attr_grp);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver lpc_drv = {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-sys-eeprom.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-sys-eeprom.c
@@ -17,7 +17,7 @@
  */
 
 /* enable dev_dbg print out */
-//#define DEBUG 
+//#define DEBUG
 
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <linux/kernel.h>
@@ -89,7 +89,7 @@ static void sys_eeprom_update_client(struct i2c_client *client, u8 slice)
                 data->data[j] = res & 0xFF;
             }
         }
-        
+
         data->last_updated[slice] = jiffies;
         data->valid |= (1 << slice);
     }
@@ -105,7 +105,7 @@ static ssize_t sys_eeprom_read(struct file *filp, struct kobject *kobj,
     struct eeprom_data *data = i2c_get_clientdata(client);
     u8 slice;
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -138,7 +138,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
 
     dev_dbg(&client->dev, "sys_eeprom_write off=%d, count=%d\n", (int)off, (int)count);
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -163,7 +163,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
         }
 
         off++;
-        
+
         /* need to wait for write complete */
         udelay(10000);
     }
@@ -195,22 +195,36 @@ static int sys_eeprom_detect(struct i2c_client *client, struct i2c_board_info *i
     /* EDID EEPROMs are often 24C00 EEPROMs, which answer to all
        addresses 0x50-0x57, but we only care about 0x51 and 0x55. So decline
        attaching to addresses >= 0x56 on DDC buses */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
     if (!(adapter->class & I2C_CLASS_SPD) && client->addr >= 0x56) {
         return -ENODEV;
     }
+#else
+    if (client->addr >= 0x56) {
+        return -ENODEV;
+    }
+#endif
 
     if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_READ_BYTE)
      && !i2c_check_functionality(adapter, I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
         return -ENODEV;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     strlcpy(info->type, "eeprom", I2C_NAME_SIZE);
+#else
+    strscpy(info->type, "eeprom", I2C_NAME_SIZE);
+#endif
 
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int sys_eeprom_probe(struct i2c_client *client,
             const struct i2c_device_id *id)
+#else
+static int sys_eeprom_probe(struct i2c_client *client)
+#endif
 {
     struct eeprom_data *data;
     int err;
@@ -271,13 +285,19 @@ static struct i2c_driver sys_eeprom_driver = {
     .remove     = sys_eeprom_remove,
     .id_table   = sys_eeprom_id,
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     .class      = I2C_CLASS_DDC | I2C_CLASS_SPD,
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+    .class      = I2C_CLASS_SPD,
+#else
+    .class      = 0,
+#endif
     .detect     = sys_eeprom_detect,
     .address_list   = normal_i2c,
 };
 
 module_i2c_driver(sys_eeprom_driver);
 
-MODULE_AUTHOR("Wade <wade.ce.he@ufispace.com>");
-MODULE_DESCRIPTION("UfiSpace Mother Board EEPROM driver");
+MODULE_AUTHOR("Leo Lin <leo.yt.lin@ufispace.com>");
+MODULE_DESCRIPTION("UfiSpace System EEPROM driver");
 MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/Makefile
@@ -1,6 +1,6 @@
 
 x86-64-ufispace-s9321-64e-cpld-objs := x86-64-ufispace-s9321-64e-cpld-main.o x86-64-ufispace-s9321-64e-cpld-mux.o
-MODULE_NAME  = x86-64-ufispace-s9321-64e-cpld.o x86-64-ufispace-s9321-64e-sys-eeprom.o x86-64-ufispace-s9321-64e-lpc.o pddf_custom_sysstatus_module.o pddf_custom_cpldmux_driver.o
+MODULE_NAME  = x86-64-ufispace-s9321-64e-cpld.o x86-64-ufispace-s9321-64e-sys-eeprom.o x86-64-ufispace-s9321-64e-lpc.o pddf_custom_sysstatus_module.o pddf_custom_cpldmux_driver.o x86-64-ufispace-s9321-64e-i2c-smbus.o
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/pddf_custom_cpldmux_driver.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/pddf_custom_cpldmux_driver.c
@@ -6,6 +6,9 @@
 
 extern PDDF_CPLDMUX_OPS pddf_cpldmux_ops;
 
+int pddf_cpldmux_select(struct i2c_mux_core *muxc, uint32_t chan);
+int pddf_cpldmux_deselect(struct i2c_mux_core *muxc, uint32_t chan);
+
 /* NOTE: Never use i2c_smbus_write_byte_data() or i2c_smbus_xfer() since these operations
  * locks the parent bus which might lead to mutex deadlock.
  */

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-cpld-main.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-cpld-main.c
@@ -1590,9 +1590,15 @@ static void cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct i2c_adapter *adap = client->adapter;
     struct device *dev = &client->dev;

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-cpld-mux.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-cpld-mux.c
@@ -207,6 +207,9 @@ static port_block_map_t ports_block_map[] = {
 
 };
 
+int port_chan_get_from_reg(u8 val, int index, int *chan, int *port);
+int mux_reg_get(struct i2c_adapter *adap, struct i2c_client *client);
+
 int port_chan_get_from_reg(u8 val, int index, int *chan, int *port)
 {
     u32 i = 0;
@@ -601,7 +604,11 @@ int mux_init(struct device *dev)
 
     /* Now create an adapter for each channel */
     for (num = 0; num < data->chip->nchans; num++) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
         ret = i2c_mux_add_adapter(muxc, 0, num, 0);
+#else
+        ret = i2c_mux_add_adapter(muxc, 0, num);
+#endif
         if (ret)
             goto exit;
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-i2c-smbus.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64e/modules/x86-64-ufispace-s9321-64e-i2c-smbus.c
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * i2c-smbus.c - SMBus extensions to the I2C protocol
+ *
+ * Copyright (C) 2008 David Brownell
+ * Copyright (C) 2010-2019 Jean Delvare <jdelvare@suse.de>
+ *
+ * In kernel 6.12.41, the system EEPROM (located on i801 bus, address 0) is misrecognized as an SPD.
+ * Since no standard method is available to resolve this conflict, this patch implements a workaround.
+ * 
+ */
+
+#include <linux/device.h>
+#include <linux/dmi.h>
+#include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/version.h>
+
+static int disable_i2c_register_spd = 1;
+module_param(disable_i2c_register_spd, int, 0);
+
+struct i2c_smbus_alert {
+	struct work_struct	alert;
+	struct i2c_client	*ara;		/* Alert response address */
+};
+
+struct alert_data {
+	unsigned short		addr;
+	enum i2c_alert_protocol	type;
+	unsigned int		data;
+};
+
+/* If this is the alerting device, notify its driver */
+static int smbus_do_alert(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+	int ret;
+
+	if (!client || client->addr != data->addr)
+		return 0;
+	if (client->flags & I2C_CLIENT_TEN)
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler.  Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert) {
+			/* Stop iterating after we find the device */
+			driver->alert(client, data->type, data->data);
+			ret = -EBUSY;
+		} else {
+			dev_warn(&client->dev, "no driver alert()!\n");
+			ret = -EOPNOTSUPP;
+		}
+	} else {
+		dev_dbg(&client->dev, "alert with no driver\n");
+		ret = -ENODEV;
+	}
+	device_unlock(dev);
+
+	return ret;
+}
+
+/* Same as above, but call back all drivers with alert handler */
+
+static int smbus_do_alert_force(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+
+	if (!client || (client->flags & I2C_CLIENT_TEN))
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler. Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert)
+			driver->alert(client, data->type, data->data);
+	}
+	device_unlock(dev);
+
+	return 0;
+}
+
+/*
+ * The alert IRQ handler needs to hand work off to a task which can issue
+ * SMBus calls, because those sleeping calls can't be made in IRQ context.
+ */
+static irqreturn_t smbus_alert(int irq, void *d)
+{
+	struct i2c_smbus_alert *alert = d;
+	struct i2c_client *ara;
+	unsigned short prev_addr = I2C_CLIENT_END; /* Not a valid address */
+
+	ara = alert->ara;
+
+	for (;;) {
+		s32 status;
+		struct alert_data data;
+
+		/*
+		 * Devices with pending alerts reply in address order, low
+		 * to high, because of slave transmit arbitration.  After
+		 * responding, an SMBus device stops asserting SMBALERT#.
+		 *
+		 * Note that SMBus 2.0 reserves 10-bit addresses for future
+		 * use.  We neither handle them, nor try to use PEC here.
+		 */
+		status = i2c_smbus_read_byte(ara);
+		if (status < 0)
+			break;
+
+		data.data = status & 1;
+		data.addr = status >> 1;
+		data.type = I2C_PROTOCOL_SMBUS_ALERT;
+
+		dev_dbg(&ara->dev, "SMBALERT# from dev 0x%02x, flag %d\n",
+			data.addr, data.data);
+
+		/* Notify driver for the device which issued the alert */
+		status = device_for_each_child(&ara->adapter->dev, &data,
+					       smbus_do_alert);
+		/*
+		 * If we read the same address more than once, and the alert
+		 * was not handled by a driver, it won't do any good to repeat
+		 * the loop because it will never terminate. Try again, this
+		 * time calling the alert handlers of all devices connected to
+		 * the bus, and abort the loop afterwards. If this helps, we
+		 * are all set. If it doesn't, there is nothing else we can do,
+		 * so we might as well abort the loop.
+		 * Note: This assumes that a driver with alert handler handles
+		 * the alert properly and clears it if necessary.
+		 */
+		if (data.addr == prev_addr && status != -EBUSY) {
+			device_for_each_child(&ara->adapter->dev, &data,
+					      smbus_do_alert_force);
+			break;
+		}
+		prev_addr = data.addr;
+	}
+
+	return IRQ_HANDLED;
+}
+
+static void smbalert_work(struct work_struct *work)
+{
+	struct i2c_smbus_alert *alert;
+
+	alert = container_of(work, struct i2c_smbus_alert, alert);
+
+	smbus_alert(0, alert);
+
+}
+
+/* Setup SMBALERT# infrastructure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int smbalert_probe(struct i2c_client *ara,
+			const struct i2c_device_id *dev_id)
+{
+#else
+static int smbalert_probe(struct i2c_client *ara)
+{
+#endif
+	struct i2c_smbus_alert_setup *setup = dev_get_platdata(&ara->dev);
+	struct i2c_smbus_alert *alert;
+	struct i2c_adapter *adapter = ara->adapter;
+	int res, irq;
+
+	alert = devm_kzalloc(&ara->dev, sizeof(struct i2c_smbus_alert),
+			     GFP_KERNEL);
+	if (!alert)
+		return -ENOMEM;
+
+	if (setup) {
+		irq = setup->irq;
+	} else {
+		irq = fwnode_irq_get_byname(dev_fwnode(adapter->dev.parent),
+					    "smbus_alert");
+		if (irq <= 0)
+			return irq;
+	}
+
+	INIT_WORK(&alert->alert, smbalert_work);
+	alert->ara = ara;
+
+	if (irq > 0) {
+		res = devm_request_threaded_irq(&ara->dev, irq,
+						NULL, smbus_alert,
+						IRQF_SHARED | IRQF_ONESHOT,
+						"smbus_alert", alert);
+		if (res)
+			return res;
+	}
+
+	i2c_set_clientdata(ara, alert);
+	dev_info(&adapter->dev, "supports SMBALERT#\n");
+
+	return 0;
+}
+
+/* IRQ and memory resources are managed so they are freed automatically */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int
+#else
+static void
+#endif
+smbalert_remove(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	cancel_work_sync(&alert->alert);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id smbalert_ids[] = {
+	{ "smbus_alert" },
+	{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, smbalert_ids);
+
+static struct i2c_driver smbalert_driver = {
+	.driver = {
+		.name	= "smbus_alert",
+	},
+	.probe		= smbalert_probe,
+	.remove		= smbalert_remove,
+	.id_table	= smbalert_ids,
+};
+
+/**
+ * i2c_handle_smbus_alert - Handle an SMBus alert
+ * @ara: the ARA client on the relevant adapter
+ * Context: can't sleep
+ *
+ * Helper function to be called from an I2C bus driver's interrupt
+ * handler. It will schedule the alert work, in turn calling the
+ * corresponding I2C device driver's alert function.
+ *
+ * It is assumed that ara is a valid i2c client previously returned by
+ * i2c_new_smbus_alert_device().
+ */
+int i2c_handle_smbus_alert(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	return schedule_work(&alert->alert);
+}
+EXPORT_SYMBOL_GPL(i2c_handle_smbus_alert);
+
+module_i2c_driver(smbalert_driver);
+
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+#define SMBUS_HOST_NOTIFY_LEN	3
+struct i2c_slave_host_notify_status {
+	u8 index;
+	u8 addr;
+};
+
+static int i2c_slave_host_notify_cb(struct i2c_client *client,
+				    enum i2c_slave_event event, u8 *val)
+{
+	struct i2c_slave_host_notify_status *status = client->dev.platform_data;
+
+	switch (event) {
+	case I2C_SLAVE_WRITE_RECEIVED:
+		/* We only retrieve the first byte received (addr)
+		 * since there is currently no support to retrieve the data
+		 * parameter from the client.
+		 */
+		if (status->index == 0)
+			status->addr = *val;
+		if (status->index < U8_MAX)
+			status->index++;
+		break;
+	case I2C_SLAVE_STOP:
+		if (status->index == SMBUS_HOST_NOTIFY_LEN)
+			i2c_handle_smbus_host_notify(client->adapter,
+						     status->addr);
+		fallthrough;
+	case I2C_SLAVE_WRITE_REQUESTED:
+		status->index = 0;
+		break;
+	case I2C_SLAVE_READ_REQUESTED:
+	case I2C_SLAVE_READ_PROCESSED:
+		*val = 0xff;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * i2c_new_slave_host_notify_device - get a client for SMBus host-notify support
+ * @adapter: the target adapter
+ * Context: can sleep
+ *
+ * Setup handling of the SMBus host-notify protocol on a given I2C bus segment.
+ *
+ * Handling is done by creating a device and its callback and handling data
+ * received via the SMBus host-notify address (0x8)
+ *
+ * This returns the client, which should be ultimately freed using
+ * i2c_free_slave_host_notify_device(); or an ERRPTR to indicate an error.
+ */
+struct i2c_client *i2c_new_slave_host_notify_device(struct i2c_adapter *adapter)
+{
+	struct i2c_board_info host_notify_board_info = {
+		I2C_BOARD_INFO("smbus_host_notify", 0x08),
+		.flags  = I2C_CLIENT_SLAVE,
+	};
+	struct i2c_slave_host_notify_status *status;
+	struct i2c_client *client;
+	int ret;
+
+	status = kzalloc(sizeof(struct i2c_slave_host_notify_status),
+			 GFP_KERNEL);
+	if (!status)
+		return ERR_PTR(-ENOMEM);
+
+	host_notify_board_info.platform_data = status;
+
+	client = i2c_new_client_device(adapter, &host_notify_board_info);
+	if (IS_ERR(client)) {
+		kfree(status);
+		return client;
+	}
+
+	ret = i2c_slave_register(client, i2c_slave_host_notify_cb);
+	if (ret) {
+		i2c_unregister_device(client);
+		kfree(status);
+		return ERR_PTR(ret);
+	}
+
+	return client;
+}
+EXPORT_SYMBOL_GPL(i2c_new_slave_host_notify_device);
+
+/**
+ * i2c_free_slave_host_notify_device - free the client for SMBus host-notify
+ * support
+ * @client: the client to free
+ * Context: can sleep
+ *
+ * Free the i2c_client allocated via i2c_new_slave_host_notify_device
+ */
+void i2c_free_slave_host_notify_device(struct i2c_client *client)
+{
+	if (IS_ERR_OR_NULL(client))
+		return;
+
+	i2c_slave_unregister(client);
+	kfree(client->dev.platform_data);
+	i2c_unregister_device(client);
+}
+EXPORT_SYMBOL_GPL(i2c_free_slave_host_notify_device);
+#endif
+
+/*
+ * SPD is not part of SMBus but we include it here for convenience as the
+ * target systems are the same.
+ * Restrictions to automatic SPD instantiation:
+ *  - Only works if all filled slots have the same memory type
+ *  - Only works for (LP)DDR memory types up to DDR5
+ *  - Only works on systems with 1 to 8 memory slots
+ */
+#if IS_ENABLED(CONFIG_DMI)
+void i2c_register_spd(struct i2c_adapter *adap)
+{
+	int n, slot_count = 0, dimm_count = 0;
+	u16 handle;
+	u8 common_mem_type = 0x0, mem_type;
+	u64 mem_size;
+	const char *name;
+
+	//disable spd scan to prevent address conflict between spd and sys eeprom
+	if (disable_i2c_register_spd == 1) {
+		return;
+	}
+
+	while ((handle = dmi_memdev_handle(slot_count)) != 0xffff) {
+		slot_count++;
+
+		/* Skip empty slots */
+		mem_size = dmi_memdev_size(handle);
+		if (!mem_size)
+			continue;
+
+		/* Skip undefined memory type */
+		mem_type = dmi_memdev_type(handle);
+		if (mem_type <= 0x02)		/* Invalid, Other, Unknown */
+			continue;
+
+		if (!common_mem_type) {
+			/* First filled slot */
+			common_mem_type = mem_type;
+		} else {
+			/* Check that all filled slots have the same type */
+			if (mem_type != common_mem_type) {
+				dev_warn(&adap->dev,
+					 "Different memory types mixed, not instantiating SPD\n");
+				return;
+			}
+		}
+		dimm_count++;
+	}
+
+	/* No useful DMI data, bail out */
+	if (!dimm_count)
+		return;
+
+	/*
+	 * The max number of SPD EEPROMs that can be addressed per bus is 8.
+	 * If more slots are present either muxed or multiple busses are
+	 * necessary or the additional slots are ignored.
+	 */
+	slot_count = min(slot_count, 8);
+
+	/*
+	 * Memory types could be found at section 7.18.2 (Memory Device — Type), table 78
+	 * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf
+	 */
+	switch (common_mem_type) {
+	case 0x12:	/* DDR */
+	case 0x13:	/* DDR2 */
+	case 0x18:	/* DDR3 */
+	case 0x1B:	/* LPDDR */
+	case 0x1C:	/* LPDDR2 */
+	case 0x1D:	/* LPDDR3 */
+		name = "spd";
+		break;
+	case 0x1A:	/* DDR4 */
+	case 0x1E:	/* LPDDR4 */
+		name = "ee1004";
+		break;
+	case 0x22:	/* DDR5 */
+	case 0x23:	/* LPDDR5 */
+		name = "spd5118";
+		break;
+	default:
+		dev_info(&adap->dev,
+			 "Memory type 0x%02x not supported yet, not instantiating SPD\n",
+			 common_mem_type);
+		return;
+	}
+
+	/*
+	 * We don't know in which slots the memory modules are. We could
+	 * try to guess from the slot names, but that would be rather complex
+	 * and unreliable, so better probe all possible addresses until we
+	 * have found all memory modules.
+	 */
+	for (n = 0; n < slot_count && dimm_count; n++) {
+		struct i2c_board_info info;
+		unsigned short addr_list[2];
+
+		memset(&info, 0, sizeof(struct i2c_board_info));
+		strscpy(info.type, name, I2C_NAME_SIZE);
+		addr_list[0] = 0x50 + n;
+		addr_list[1] = I2C_CLIENT_END;
+
+		if (!IS_ERR(i2c_new_scanned_device(adap, &info, addr_list, NULL))) {
+			dev_info(&adap->dev,
+				 "Successfully instantiated SPD at 0x%hx\n",
+				 addr_list[0]);
+			dimm_count--;
+		}
+	}
+}
+EXPORT_SYMBOL_GPL(i2c_register_spd);
+#endif
+
+MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+MODULE_DESCRIPTION("SMBus protocol extensions support");
+MODULE_LICENSE("GPL");

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/Makefile
@@ -1,6 +1,6 @@
 
 x86-64-ufispace-s9321-64eo-cpld-objs := x86-64-ufispace-s9321-64eo-cpld-main.o x86-64-ufispace-s9321-64eo-cpld-mux.o
-MODULE_NAME  = x86-64-ufispace-s9321-64eo-cpld.o x86-64-ufispace-s9321-64eo-sys-eeprom.o x86-64-ufispace-s9321-64eo-lpc.o pddf_custom_sysstatus_module.o pddf_custom_cpldmux_driver.o
+MODULE_NAME  = x86-64-ufispace-s9321-64eo-cpld.o x86-64-ufispace-s9321-64eo-sys-eeprom.o x86-64-ufispace-s9321-64eo-lpc.o pddf_custom_sysstatus_module.o pddf_custom_cpldmux_driver.o x86-64-ufispace-s9321-64eo-i2c-smbus.o
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/pddf_custom_cpldmux_driver.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/pddf_custom_cpldmux_driver.c
@@ -6,6 +6,9 @@
 
 extern PDDF_CPLDMUX_OPS pddf_cpldmux_ops;
 
+int pddf_cpldmux_select(struct i2c_mux_core *muxc, uint32_t chan);
+int pddf_cpldmux_deselect(struct i2c_mux_core *muxc, uint32_t chan);
+
 /* NOTE: Never use i2c_smbus_write_byte_data() or i2c_smbus_xfer() since these operations
  * locks the parent bus which might lead to mutex deadlock.
  */

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/pddf_custom_sysstatus_module.c
@@ -57,7 +57,8 @@ PDDF_DATA_ATTR(attr_len, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_
               sizeof(uint32_t), (void*)&sysstatus_data.sysstatus_addr_attr.len , NULL);
 PDDF_DATA_ATTR(attr_ops, S_IWUSR, NULL, do_attr_operation, PDDF_CHAR, 8, (void*)&sysstatus_data, NULL);
 
-
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 static struct attribute *sysstatus_addr_attributes[] = {
     &attr_attr_name.dev_attr.attr,

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-cpld-main.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-cpld-main.c
@@ -1596,9 +1596,15 @@ static void cpld_remove_client(struct i2c_client *client)
 }
 
 /* cpld drvier probe */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int cpld_probe(struct i2c_client *client,
                     const struct i2c_device_id *dev_id)
 {
+#else
+static int cpld_probe(struct i2c_client *client)
+{
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
+#endif
     int status;
     struct i2c_adapter *adap = client->adapter;
     struct device *dev = &client->dev;

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-cpld-mux.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-cpld-mux.c
@@ -207,6 +207,9 @@ static port_block_map_t ports_block_map[] = {
 
 };
 
+int port_chan_get_from_reg(u8 val, int index, int *chan, int *port);
+int mux_reg_get(struct i2c_adapter *adap, struct i2c_client *client);
+
 int port_chan_get_from_reg(u8 val, int index, int *chan, int *port)
 {
     u32 i = 0;
@@ -601,7 +604,11 @@ int mux_init(struct device *dev)
 
     /* Now create an adapter for each channel */
     for (num = 0; num < data->chip->nchans; num++) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
         ret = i2c_mux_add_adapter(muxc, 0, num, 0);
+#else
+        ret = i2c_mux_add_adapter(muxc, 0, num);
+#endif
         if (ret)
             goto exit;
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-i2c-smbus.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9321-64eo/modules/x86-64-ufispace-s9321-64eo-i2c-smbus.c
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * i2c-smbus.c - SMBus extensions to the I2C protocol
+ *
+ * Copyright (C) 2008 David Brownell
+ * Copyright (C) 2010-2019 Jean Delvare <jdelvare@suse.de>
+ *
+ * In kernel 6.12.41, the system EEPROM (located on i801 bus, address 0) is misrecognized as an SPD.
+ * Since no standard method is available to resolve this conflict, this patch implements a workaround.
+ * 
+ */
+
+#include <linux/device.h>
+#include <linux/dmi.h>
+#include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/version.h>
+
+static int disable_i2c_register_spd = 1;
+module_param(disable_i2c_register_spd, int, 0);
+
+struct i2c_smbus_alert {
+	struct work_struct	alert;
+	struct i2c_client	*ara;		/* Alert response address */
+};
+
+struct alert_data {
+	unsigned short		addr;
+	enum i2c_alert_protocol	type;
+	unsigned int		data;
+};
+
+/* If this is the alerting device, notify its driver */
+static int smbus_do_alert(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+	int ret;
+
+	if (!client || client->addr != data->addr)
+		return 0;
+	if (client->flags & I2C_CLIENT_TEN)
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler.  Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert) {
+			/* Stop iterating after we find the device */
+			driver->alert(client, data->type, data->data);
+			ret = -EBUSY;
+		} else {
+			dev_warn(&client->dev, "no driver alert()!\n");
+			ret = -EOPNOTSUPP;
+		}
+	} else {
+		dev_dbg(&client->dev, "alert with no driver\n");
+		ret = -ENODEV;
+	}
+	device_unlock(dev);
+
+	return ret;
+}
+
+/* Same as above, but call back all drivers with alert handler */
+
+static int smbus_do_alert_force(struct device *dev, void *addrp)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct alert_data *data = addrp;
+	struct i2c_driver *driver;
+
+	if (!client || (client->flags & I2C_CLIENT_TEN))
+		return 0;
+
+	/*
+	 * Drivers should either disable alerts, or provide at least
+	 * a minimal handler. Lock so the driver won't change.
+	 */
+	device_lock(dev);
+	if (client->dev.driver) {
+		driver = to_i2c_driver(client->dev.driver);
+		if (driver->alert)
+			driver->alert(client, data->type, data->data);
+	}
+	device_unlock(dev);
+
+	return 0;
+}
+
+/*
+ * The alert IRQ handler needs to hand work off to a task which can issue
+ * SMBus calls, because those sleeping calls can't be made in IRQ context.
+ */
+static irqreturn_t smbus_alert(int irq, void *d)
+{
+	struct i2c_smbus_alert *alert = d;
+	struct i2c_client *ara;
+	unsigned short prev_addr = I2C_CLIENT_END; /* Not a valid address */
+
+	ara = alert->ara;
+
+	for (;;) {
+		s32 status;
+		struct alert_data data;
+
+		/*
+		 * Devices with pending alerts reply in address order, low
+		 * to high, because of slave transmit arbitration.  After
+		 * responding, an SMBus device stops asserting SMBALERT#.
+		 *
+		 * Note that SMBus 2.0 reserves 10-bit addresses for future
+		 * use.  We neither handle them, nor try to use PEC here.
+		 */
+		status = i2c_smbus_read_byte(ara);
+		if (status < 0)
+			break;
+
+		data.data = status & 1;
+		data.addr = status >> 1;
+		data.type = I2C_PROTOCOL_SMBUS_ALERT;
+
+		dev_dbg(&ara->dev, "SMBALERT# from dev 0x%02x, flag %d\n",
+			data.addr, data.data);
+
+		/* Notify driver for the device which issued the alert */
+		status = device_for_each_child(&ara->adapter->dev, &data,
+					       smbus_do_alert);
+		/*
+		 * If we read the same address more than once, and the alert
+		 * was not handled by a driver, it won't do any good to repeat
+		 * the loop because it will never terminate. Try again, this
+		 * time calling the alert handlers of all devices connected to
+		 * the bus, and abort the loop afterwards. If this helps, we
+		 * are all set. If it doesn't, there is nothing else we can do,
+		 * so we might as well abort the loop.
+		 * Note: This assumes that a driver with alert handler handles
+		 * the alert properly and clears it if necessary.
+		 */
+		if (data.addr == prev_addr && status != -EBUSY) {
+			device_for_each_child(&ara->adapter->dev, &data,
+					      smbus_do_alert_force);
+			break;
+		}
+		prev_addr = data.addr;
+	}
+
+	return IRQ_HANDLED;
+}
+
+static void smbalert_work(struct work_struct *work)
+{
+	struct i2c_smbus_alert *alert;
+
+	alert = container_of(work, struct i2c_smbus_alert, alert);
+
+	smbus_alert(0, alert);
+
+}
+
+/* Setup SMBALERT# infrastructure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int smbalert_probe(struct i2c_client *ara,
+			const struct i2c_device_id *dev_id)
+{
+#else
+static int smbalert_probe(struct i2c_client *ara)
+{
+#endif
+	struct i2c_smbus_alert_setup *setup = dev_get_platdata(&ara->dev);
+	struct i2c_smbus_alert *alert;
+	struct i2c_adapter *adapter = ara->adapter;
+	int res, irq;
+
+	alert = devm_kzalloc(&ara->dev, sizeof(struct i2c_smbus_alert),
+			     GFP_KERNEL);
+	if (!alert)
+		return -ENOMEM;
+
+	if (setup) {
+		irq = setup->irq;
+	} else {
+		irq = fwnode_irq_get_byname(dev_fwnode(adapter->dev.parent),
+					    "smbus_alert");
+		if (irq <= 0)
+			return irq;
+	}
+
+	INIT_WORK(&alert->alert, smbalert_work);
+	alert->ara = ara;
+
+	if (irq > 0) {
+		res = devm_request_threaded_irq(&ara->dev, irq,
+						NULL, smbus_alert,
+						IRQF_SHARED | IRQF_ONESHOT,
+						"smbus_alert", alert);
+		if (res)
+			return res;
+	}
+
+	i2c_set_clientdata(ara, alert);
+	dev_info(&adapter->dev, "supports SMBALERT#\n");
+
+	return 0;
+}
+
+/* IRQ and memory resources are managed so they are freed automatically */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int
+#else
+static void
+#endif
+smbalert_remove(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	cancel_work_sync(&alert->alert);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id smbalert_ids[] = {
+	{ "smbus_alert" },
+	{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, smbalert_ids);
+
+static struct i2c_driver smbalert_driver = {
+	.driver = {
+		.name	= "smbus_alert",
+	},
+	.probe		= smbalert_probe,
+	.remove		= smbalert_remove,
+	.id_table	= smbalert_ids,
+};
+
+/**
+ * i2c_handle_smbus_alert - Handle an SMBus alert
+ * @ara: the ARA client on the relevant adapter
+ * Context: can't sleep
+ *
+ * Helper function to be called from an I2C bus driver's interrupt
+ * handler. It will schedule the alert work, in turn calling the
+ * corresponding I2C device driver's alert function.
+ *
+ * It is assumed that ara is a valid i2c client previously returned by
+ * i2c_new_smbus_alert_device().
+ */
+int i2c_handle_smbus_alert(struct i2c_client *ara)
+{
+	struct i2c_smbus_alert *alert = i2c_get_clientdata(ara);
+
+	return schedule_work(&alert->alert);
+}
+EXPORT_SYMBOL_GPL(i2c_handle_smbus_alert);
+
+module_i2c_driver(smbalert_driver);
+
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+#define SMBUS_HOST_NOTIFY_LEN	3
+struct i2c_slave_host_notify_status {
+	u8 index;
+	u8 addr;
+};
+
+static int i2c_slave_host_notify_cb(struct i2c_client *client,
+				    enum i2c_slave_event event, u8 *val)
+{
+	struct i2c_slave_host_notify_status *status = client->dev.platform_data;
+
+	switch (event) {
+	case I2C_SLAVE_WRITE_RECEIVED:
+		/* We only retrieve the first byte received (addr)
+		 * since there is currently no support to retrieve the data
+		 * parameter from the client.
+		 */
+		if (status->index == 0)
+			status->addr = *val;
+		if (status->index < U8_MAX)
+			status->index++;
+		break;
+	case I2C_SLAVE_STOP:
+		if (status->index == SMBUS_HOST_NOTIFY_LEN)
+			i2c_handle_smbus_host_notify(client->adapter,
+						     status->addr);
+		fallthrough;
+	case I2C_SLAVE_WRITE_REQUESTED:
+		status->index = 0;
+		break;
+	case I2C_SLAVE_READ_REQUESTED:
+	case I2C_SLAVE_READ_PROCESSED:
+		*val = 0xff;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * i2c_new_slave_host_notify_device - get a client for SMBus host-notify support
+ * @adapter: the target adapter
+ * Context: can sleep
+ *
+ * Setup handling of the SMBus host-notify protocol on a given I2C bus segment.
+ *
+ * Handling is done by creating a device and its callback and handling data
+ * received via the SMBus host-notify address (0x8)
+ *
+ * This returns the client, which should be ultimately freed using
+ * i2c_free_slave_host_notify_device(); or an ERRPTR to indicate an error.
+ */
+struct i2c_client *i2c_new_slave_host_notify_device(struct i2c_adapter *adapter)
+{
+	struct i2c_board_info host_notify_board_info = {
+		I2C_BOARD_INFO("smbus_host_notify", 0x08),
+		.flags  = I2C_CLIENT_SLAVE,
+	};
+	struct i2c_slave_host_notify_status *status;
+	struct i2c_client *client;
+	int ret;
+
+	status = kzalloc(sizeof(struct i2c_slave_host_notify_status),
+			 GFP_KERNEL);
+	if (!status)
+		return ERR_PTR(-ENOMEM);
+
+	host_notify_board_info.platform_data = status;
+
+	client = i2c_new_client_device(adapter, &host_notify_board_info);
+	if (IS_ERR(client)) {
+		kfree(status);
+		return client;
+	}
+
+	ret = i2c_slave_register(client, i2c_slave_host_notify_cb);
+	if (ret) {
+		i2c_unregister_device(client);
+		kfree(status);
+		return ERR_PTR(ret);
+	}
+
+	return client;
+}
+EXPORT_SYMBOL_GPL(i2c_new_slave_host_notify_device);
+
+/**
+ * i2c_free_slave_host_notify_device - free the client for SMBus host-notify
+ * support
+ * @client: the client to free
+ * Context: can sleep
+ *
+ * Free the i2c_client allocated via i2c_new_slave_host_notify_device
+ */
+void i2c_free_slave_host_notify_device(struct i2c_client *client)
+{
+	if (IS_ERR_OR_NULL(client))
+		return;
+
+	i2c_slave_unregister(client);
+	kfree(client->dev.platform_data);
+	i2c_unregister_device(client);
+}
+EXPORT_SYMBOL_GPL(i2c_free_slave_host_notify_device);
+#endif
+
+/*
+ * SPD is not part of SMBus but we include it here for convenience as the
+ * target systems are the same.
+ * Restrictions to automatic SPD instantiation:
+ *  - Only works if all filled slots have the same memory type
+ *  - Only works for (LP)DDR memory types up to DDR5
+ *  - Only works on systems with 1 to 8 memory slots
+ */
+#if IS_ENABLED(CONFIG_DMI)
+void i2c_register_spd(struct i2c_adapter *adap)
+{
+	int n, slot_count = 0, dimm_count = 0;
+	u16 handle;
+	u8 common_mem_type = 0x0, mem_type;
+	u64 mem_size;
+	const char *name;
+
+	//disable spd scan to prevent address conflict between spd and sys eeprom
+	if (disable_i2c_register_spd == 1) {
+		return;
+	}
+
+	while ((handle = dmi_memdev_handle(slot_count)) != 0xffff) {
+		slot_count++;
+
+		/* Skip empty slots */
+		mem_size = dmi_memdev_size(handle);
+		if (!mem_size)
+			continue;
+
+		/* Skip undefined memory type */
+		mem_type = dmi_memdev_type(handle);
+		if (mem_type <= 0x02)		/* Invalid, Other, Unknown */
+			continue;
+
+		if (!common_mem_type) {
+			/* First filled slot */
+			common_mem_type = mem_type;
+		} else {
+			/* Check that all filled slots have the same type */
+			if (mem_type != common_mem_type) {
+				dev_warn(&adap->dev,
+					 "Different memory types mixed, not instantiating SPD\n");
+				return;
+			}
+		}
+		dimm_count++;
+	}
+
+	/* No useful DMI data, bail out */
+	if (!dimm_count)
+		return;
+
+	/*
+	 * The max number of SPD EEPROMs that can be addressed per bus is 8.
+	 * If more slots are present either muxed or multiple busses are
+	 * necessary or the additional slots are ignored.
+	 */
+	slot_count = min(slot_count, 8);
+
+	/*
+	 * Memory types could be found at section 7.18.2 (Memory Device — Type), table 78
+	 * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf
+	 */
+	switch (common_mem_type) {
+	case 0x12:	/* DDR */
+	case 0x13:	/* DDR2 */
+	case 0x18:	/* DDR3 */
+	case 0x1B:	/* LPDDR */
+	case 0x1C:	/* LPDDR2 */
+	case 0x1D:	/* LPDDR3 */
+		name = "spd";
+		break;
+	case 0x1A:	/* DDR4 */
+	case 0x1E:	/* LPDDR4 */
+		name = "ee1004";
+		break;
+	case 0x22:	/* DDR5 */
+	case 0x23:	/* LPDDR5 */
+		name = "spd5118";
+		break;
+	default:
+		dev_info(&adap->dev,
+			 "Memory type 0x%02x not supported yet, not instantiating SPD\n",
+			 common_mem_type);
+		return;
+	}
+
+	/*
+	 * We don't know in which slots the memory modules are. We could
+	 * try to guess from the slot names, but that would be rather complex
+	 * and unreliable, so better probe all possible addresses until we
+	 * have found all memory modules.
+	 */
+	for (n = 0; n < slot_count && dimm_count; n++) {
+		struct i2c_board_info info;
+		unsigned short addr_list[2];
+
+		memset(&info, 0, sizeof(struct i2c_board_info));
+		strscpy(info.type, name, I2C_NAME_SIZE);
+		addr_list[0] = 0x50 + n;
+		addr_list[1] = I2C_CLIENT_END;
+
+		if (!IS_ERR(i2c_new_scanned_device(adap, &info, addr_list, NULL))) {
+			dev_info(&adap->dev,
+				 "Successfully instantiated SPD at 0x%hx\n",
+				 addr_list[0]);
+			dimm_count--;
+		}
+	}
+}
+EXPORT_SYMBOL_GPL(i2c_register_spd);
+#endif
+
+MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+MODULE_DESCRIPTION("SMBus protocol extensions support");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION

# The following are the changes made to get the modules to compile and load:
* Start updating the build rules
* Update probe function signature in the i2c_driver instance, dropping the i2c_device_id parameter.
* Remove I2C_CLASS_SPD attribute added by the modules.
* Update remove function signature in the platform_driver and instances, dropping return values.
* Update i2c_mux_add_adapter args, dropping excess arguments (if more than 3 were passed).
* Replace strlcpy with strscpy.
* Replace i2c-smbus driver with the i2c-smbus driver from the platforms to address i2c spd address conflict at 0x57 in Debian 13.
* Address compile warnings.
* Replace eeprom driver with at24 eeprom driver due to the removal of the eeprom driver from mainstream

# Test Log
[s6301-56st.txt](https://github.com/user-attachments/files/23574187/s6301-56st.txt)
[s7801-54xs.txt](https://github.com/user-attachments/files/23574189/s7801-54xs.txt)
[s8901-54xc.txt](https://github.com/user-attachments/files/23574190/s8901-54xc.txt)
[s9110-32x.txt](https://github.com/user-attachments/files/23574191/s9110-32x.txt)
[s9300-32d.txt](https://github.com/user-attachments/files/23574192/s9300-32d.txt)
[s9301-32d.txt](https://github.com/user-attachments/files/23574193/s9301-32d.txt)
[s9301-32db.txt](https://github.com/user-attachments/files/23574194/s9301-32db.txt)
[s9321-64e.txt](https://github.com/user-attachments/files/23574195/s9321-64e.txt)
[s9321-64eo.txt](https://github.com/user-attachments/files/23574196/s9321-64eo.txt)
