### PR TITLE
[Trixie][Ufispace] Update ufispace s9311-64d platform module for Trixie

### DIFF
--- a/device/ufispace/x86_64-ufispace_s9311_64d-r0/pddf/pddf-device-alpha.json
+++ b/device/ufispace/x86_64-ufispace_s9311_64d-r0/pddf/pddf-device-alpha.json
@@ -40,6 +40,8 @@
             "pddf_cpldmux_module",
             "pddf_cpldmux_driver",
             "pddf_xcvr_module",
+            "pddf_multifpgapci_i2c_module",
+            "pddf_multifpgapci_driver",
             "pddf_fpgapci_driver",
             "pddf_xcvr_driver_module",
             "pddf_psu_driver_module",

--- a/device/ufispace/x86_64-ufispace_s9311_64d-r0/pddf/pddf-device-beta.json
+++ b/device/ufispace/x86_64-ufispace_s9311_64d-r0/pddf/pddf-device-beta.json
@@ -40,6 +40,8 @@
             "pddf_cpldmux_module",
             "pddf_cpldmux_driver",
             "pddf_xcvr_module",
+            "pddf_multifpgapci_i2c_module",
+            "pddf_multifpgapci_driver",
             "pddf_fpgapci_driver",
             "pddf_xcvr_driver_module",
             "pddf_psu_driver_module",

--- a/platform/broadcom/sonic-platform-modules-ufispace/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-ufispace/debian/rules
@@ -70,6 +70,11 @@ override_dh_auto_build:
 			fi; \
 			cd $(MOD_SRC_DIR); \
 		fi; \
+		if [ -f $(MOD_SRC_DIR)/$${mod}/sonic_platform_setup.py ]; then \
+			cd $(MOD_SRC_DIR)/$${mod}; \
+			python3 sonic_platform_setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}; \
+			cd $(MOD_SRC_DIR); \
+		fi; \
 	done)
 
 override_dh_usrlocal:

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/Makefile
@@ -4,4 +4,4 @@ MODULE_NAME  = x86-64-ufispace-s9311-64d-cpld.o x86-64-ufispace-s9311-64d-sys-ee
 obj-m       := $(MODULE_NAME)
 
 CFLAGS_pddf_custom_sysstatus_module.o := -I$(M)/../../../../pddf/i2c/modules/include
-KBUILD_EXTRA_SYMBOLS := $(M)/../../../../pddf/i2c/Module.symvers.PDDF
+KBUILD_EXTRA_SYMBOLS := $(KERNEL_SRC)/Module.symvers.PDDF

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/pddf_custom_sysstatus_module.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/pddf_custom_sysstatus_module.c
@@ -44,6 +44,8 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
 ssize_t show_sysstatus_data(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t store_sysstatus_data(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
+int __init sysstatus_data_init(void);
+void __exit sysstatus_data_exit(void);
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32,
              (void*)&sysstatus_data.sysstatus_addr_attr.aname, NULL);
@@ -266,7 +268,7 @@ static ssize_t do_attr_operation(struct device *dev, struct device_attribute *da
     pddf_dbg(SYSSTATUS, KERN_ERR "%s: Populating the data for %s\n", __FUNCTION__, pdata->sysstatus_addr_attr.aname);
 
 #ifdef __STDC_LIB_EXT1__
-    memset_s(&pdata->sysstatus_addr_attr, sizeof(pdata->sysstatus_addr_attr, 0, sizeof(pdata->sysstatus_addr_attr));
+    memset_s(&pdata->sysstatus_addr_attr, sizeof(pdata->sysstatus_addr_attr), 0, sizeof(pdata->sysstatus_addr_attr));
 #else
     _memset(&pdata->sysstatus_addr_attr, 0, sizeof(pdata->sysstatus_addr_attr));
 #endif

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-cpld-mux.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-cpld-mux.c
@@ -302,6 +302,9 @@ static port_block_map_t ports_block_map[] = {
     [65] = {.reg = CPLD_MGMT_PORT_STUCK_REG, .evt_reg = CPLD_MGMT_PORT_STUCK_EVENT_REG, .mask = MASK_0001_0000, PORT_NONE_BLOCK},
 };
 
+int port_chan_get_from_reg(u8 val, int index, int *chan, int *port);
+int mux_reg_get(struct i2c_adapter *adap, struct i2c_client *client);
+
 int port_chan_get_from_reg(u8 val, int index, int *chan, int *port)
 {
     u32 i = 0;
@@ -761,7 +764,11 @@ int mux_init(struct device *dev)
     /* Now create an adapter for each channel */
     for (num = 0; num < data->chip->nchans; num++)
     {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
         ret = i2c_mux_add_adapter(muxc, 0, num, 0);
+#else
+        ret = i2c_mux_add_adapter(muxc, 0, num);
+#endif
         if (ret)
             goto exit;
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-lpc.c
@@ -983,14 +983,20 @@ exit:
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int lpc_drv_remove(struct platform_device *pdev)
+#else
+static void lpc_drv_remove(struct platform_device *pdev)
+#endif
 {
     sysfs_remove_group(&pdev->dev.kobj, &mb_cpld_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &ec_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &i2c_alert_attr_grp);
     sysfs_remove_group(&pdev->dev.kobj, &bsp_attr_grp);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver lpc_drv = {

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-sys-eeprom.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9311-64d/modules/x86-64-ufispace-s9311-64d-sys-eeprom.c
@@ -105,7 +105,7 @@ static ssize_t sys_eeprom_read(struct file *filp, struct kobject *kobj,
     struct eeprom_data *data = i2c_get_clientdata(client);
     u8 slice;
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -138,7 +138,7 @@ static ssize_t sys_eeprom_write(struct file *filp, struct kobject *kobj,
 
     dev_dbg(&client->dev, "sys_eeprom_write off=%d, count=%d\n", (int)off, (int)count);
 
-    if (off > EEPROM_SIZE) {
+    if (off >= EEPROM_SIZE) {
         return 0;
     }
     if (off + count > EEPROM_SIZE) {
@@ -195,22 +195,36 @@ static int sys_eeprom_detect(struct i2c_client *client, struct i2c_board_info *i
     /* EDID EEPROMs are often 24C00 EEPROMs, which answer to all
        addresses 0x50-0x57, but we only care about 0x51 and 0x55. So decline
        attaching to addresses >= 0x56 on DDC buses */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
     if (!(adapter->class & I2C_CLASS_SPD) && client->addr >= 0x56) {
         return -ENODEV;
     }
+#else
+    if (client->addr >= 0x56) {
+        return -ENODEV;
+    }
+#endif
 
     if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_READ_BYTE)
      && !i2c_check_functionality(adapter, I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
         return -ENODEV;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     strlcpy(info->type, "eeprom", I2C_NAME_SIZE);
+#else
+    strscpy(info->type, "eeprom", I2C_NAME_SIZE);
+#endif
 
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int sys_eeprom_probe(struct i2c_client *client,
             const struct i2c_device_id *id)
+#else
+static int sys_eeprom_probe(struct i2c_client *client)
+#endif
 {
     struct eeprom_data *data;
     int err;
@@ -225,6 +239,7 @@ static int sys_eeprom_probe(struct i2c_client *client,
 #else
     _memset(data->data, 0xff, EEPROM_SIZE);
 #endif
+
     i2c_set_clientdata(client, data);
     mutex_init(&data->update_lock);
 
@@ -270,7 +285,13 @@ static struct i2c_driver sys_eeprom_driver = {
     .remove     = sys_eeprom_remove,
     .id_table   = sys_eeprom_id,
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
     .class      = I2C_CLASS_DDC | I2C_CLASS_SPD,
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+    .class      = I2C_CLASS_SPD,
+#else
+    .class      = 0,
+#endif
     .detect     = sys_eeprom_detect,
     .address_list   = normal_i2c,
 };


### PR DESCRIPTION
# The following are the changes made to get the modules to compile and load:
* Start updating the build rules
* Update probe function signature in the i2c_driver instance, dropping the i2c_device_id parameter.
* Remove I2C_CLASS_SPD attribute added by the modules.
* Update remove function signature in the platform_driver and instances, dropping return values.
* Update i2c_mux_add_adapter args, dropping excess arguments (if more than 3 were passed).
* Replace strlcpy with strscpy.
* Address compile warnings.

# Test Log
* [s9311-64d.txt](https://github.com/user-attachments/files/23601273/s9311-64d.txt)
