### PR TITLE
Marvell prestera sai version 1.16.1 3

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.16.1-2
+MRVL_SAI_VERSION = 1.16.1-3
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.16.1-2
+MRVL_SAI_VERSION = 1.16.1-3
 else
-MRVL_SAI_VERSION = 1.16.1-2
+MRVL_SAI_VERSION = 1.16.1-3
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Marvell-prestera SAI version 1.6.1-2 used on 202505 and master branches
is unstable on TRIXIE.
Replace it by new SAI version 1.6.1-3 working properly on TRIXIE.

#### How I did it
Increment SAI version number in the platform/marvell-prestera/sai.mk file
pointing to Marvell repo binaries

#### How to verify it
Build and run TRIXIE, check 5 times once-a-minute that the "show interfaces status"
and "msai" commands are working properly.

#### Which release branch to backport (provide reason below if selected)
NONE

#### Description for the changelog
#### A picture of a cute animal (not mandatory but encouraged)

