### PR TITLE
marvell-prestera: fix script nokia-7215init.sh

### DIFF
--- a/platform/marvell-prestera/sonic-platform-nokia/7215/scripts/nokia-7215init.sh
+++ b/platform/marvell-prestera/sonic-platform-nokia/7215/scripts/nokia-7215init.sh
@@ -22,7 +22,7 @@ load_kernel_drivers_late() {
     # Override mvGpioDrv.ko built-in mrvllibsai.deb with correct one
     GOOD="/usr/lib/modules/$(uname -r)/kernel/extra/mvGpioDrv.ko"
     find /var/lib/docker/overlay2/*/diff/usr/lib/modules -type f -name mvGpioDrv.ko \
-         -exec sh -c 'cp -a "$0" "$1" 2>/dev/null || true' "$GOOD" {} \;}
+         -exec sh -c 'cp -a "$0" "$1" 2>/dev/null || true' "$GOOD" {} \;
 }
 
 nokia_7215_profile()


### PR DESCRIPTION
#### Why I did it
Fix syntax in platform/marvell-prestera:NOKIA: nokia-7215init.sh
The syntax bug prevents correct mvGpioDrv installation

#### How I did it
#### How to verify it
#### Which release branch to backport (provide reason below if selected)
 NONE
#### Description for the changelog
#### A picture of a cute animal (not mandatory but encouraged)

