### PR TITLE
[Debian 13] [nvidia-bluefield] Stop database from starting without the dpu having an IP

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -698,6 +698,10 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl disable midplane-network-dpu.servi
 sudo sed -i 's/#ManageForeignRoutingPolicyRules=yes/ManageForeignRoutingPolicyRules=no/g' $FILESYSTEM_ROOT/etc/systemd/networkd.conf
 sudo mkdir $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/systemd-networkd.service.d
 sudo cp $IMAGE_CONFIGS/midplane-network/systemd-networkd.override.conf $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/systemd-networkd.service.d/override.conf
+
+# Copy systemd-networkd-wait-online override configuration
+sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/systemd-networkd-wait-online.service.d
+sudo cp $IMAGE_CONFIGS/midplane-network/systemd-networkd-wait-online.override.conf $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/systemd-networkd-wait-online.service.d/override.conf
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable systemd-networkd-wait-online.service
 
 # Copy backend-acl script and service file

--- a/files/image_config/midplane-network/systemd-networkd-wait-online.override.conf
+++ b/files/image_config/midplane-network/systemd-networkd-wait-online.override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --timeout=600


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
systemd-networkd-wait-online by default waits for 2mins after which it timesout. This is causing database to start even without ip. This situation is encountered if it takes more than 2 minutes for the dpu to get IP. This happens especially after a reboot of smartswitch and it takes over 2 minutes for dhcp_server on the switch to start and handout IP to DPU.

<img width="874" height="204" alt="image" src="https://github.com/user-attachments/assets/fde77257-e687-4aa5-9ab6-ee8d535e8a9a" />

#### How I did it
Increase the timeout to 10 minutes similar to what was there before in Debian 12. 

#### How to verify it
Reboot the switch and Verify that database container starts only after obtaining IP or after waiting for 10minutes.
After the fix
<img width="836" height="186" alt="image" src="https://github.com/user-attachments/assets/e08fe6ee-7460-4180-85b4-79cca6e5229e" />

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

