### PR TITLE
Fix Makefile.work to correctly pass SECURE_UPGRADE_PROD_TOOL_ARGS

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -343,6 +343,11 @@ ifneq ($(SECURE_UPGRADE_PROD_SIGNING_TOOL),)
 	DOCKER_RUN += -v $(SECURE_UPGRADE_PROD_SIGNING_TOOL):/sonic/scripts/$(shell basename -- $(SECURE_UPGRADE_PROD_SIGNING_TOOL)):ro
 endif
 
+# Pass the Signing prod tool arguments as environment variable to avoid make command-line parsing issues
+ifneq ($(SECURE_UPGRADE_PROD_TOOL_ARGS),)
+	DOCKER_RUN += -e "SECURE_UPGRADE_PROD_TOOL_ARGS=$(SECURE_UPGRADE_PROD_TOOL_ARGS)"
+endif
+
 ifneq ($(SONIC_DPKG_CACHE_SOURCE),)
 	DOCKER_RUN += -v "$(SONIC_DPKG_CACHE_SOURCE):/dpkg_cache:rw"
 endif
@@ -561,7 +566,6 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            SECURE_UPGRADE_SIGNING_CERT=$(SECURE_UPGRADE_SIGNING_CERT) \
                            SECURE_UPGRADE_KERNEL_CAFILE=$(SECURE_UPGRADE_KERNEL_CAFILE) \
                            SECURE_UPGRADE_PROD_SIGNING_TOOL=$(SECURE_UPGRADE_PROD_SIGNING_TOOL) \
-                           SECURE_UPGRADE_PROD_TOOL_ARGS="\"'$(SECURE_UPGRADE_PROD_TOOL_ARGS)'\"" \
                            SONIC_DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
                            ENABLE_HOST_SERVICE_ON_START=$(ENABLE_HOST_SERVICE_ON_START) \
                            SLAVE_DIR=$(SLAVE_DIR) \
@@ -606,6 +610,7 @@ export MIRROR_SECURITY_URLS
 export MIRROR_SNAPSHOT
 export SONIC_VERSION_CONTROL_COMPONENTS
 export PIP_HTTP_TIMEOUT
+export SECURE_UPGRADE_PROD_TOOL_ARGS
 
 %:: | sonic-build-hooks
 ifneq ($(filter y, $(MULTIARCH_QEMU_ENVIRON) $(CROSS_BUILD_ENVIRON)),)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
when we check the processes being executed on the slave container we see that the quotes for SECURE_UPGRADE_PROD_TOOL_ARGS are gone and this resulting in the following error

```
07:41:33  make[3]: Entering directory '/sonic/src/sonic-linux-kernel/linux-6.12.41'
07:41:33  make[3]: *** No rule to make target '-c\'.  Stop.
07:41:33  make[3]: Leaving directory '/sonic/src/sonic-linux-kernel/linux-6.12.41'
07:41:33  make[2]: *** [debian/rules:65: build-indep] Error 2
07:41:33  make[2]: Leaving directory '/sonic/src/sonic-linux-kernel/linux-6.12.41'
07:41:33  dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
07:41:33  make[1]: *** [Makefile:50: /sonic/target/debs/trixie/linux-headers-6.12.41+deb13-common-sonic_6.12.41-1_all.deb] Error 2
```

Here is the `ps` output showing the slave.mk process that's being executed.
```
htirupa+       8  4.9  0.0  12748 12064 pts/0    S+   08:06   0:02 make -f slave.mk PLATFORM= PLATFORM_ARCH=amd64 MULTIARCH_QEMU_ENVIRON=n TARGET_BOOTLOADER=grub CROSS_BUILD_ENVIRON=n BUILD_NUMBER= 
...
SECURE_UPGRADE_DEV_SIGNING_KEY=key.pem 
SECURE_UPGRADE_SIGNING_CERT=cert.pem 
SECURE_UPGRADE_KERNEL_CAFILE=cert-prod.pem SECURE_UPGRADE_PROD_SIGNING_TOOL=signing_secure_boot_prod.sh 
SECURE_UPGRADE_PROD_TOOL_ARGS=-m prod -c ****  SONIC_DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io/ ENABLE_HOST_SERVICE_ON_START=y SONIC_BUILD_TARGET=target/debs/trixie/linux-headers-6.12.41+deb13-common-sonic_6.12.41-1_all.deb
```


#### How I did it
Fix Makefile.work to correctly pass SECURE_UPGRADE_PROD_TOOL_ARGS to slave.mk

#### How to verify it
We shouldn't see the above error when building linux headers package prod build
